### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  checks:
+    name: ${{ matrix.check }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        check: [fmt, clippy, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - if: matrix.check == 'fmt'
+        run: cargo fmt --check
+
+      - if: matrix.check == 'clippy'
+        run: cargo clippy -- -D warnings
+
+      - if: matrix.check == 'test'
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        check: [fmt, clippy, test]
+        include:
+          - check: fmt
+            command: cargo fmt --check
+          - check: clippy
+            command: cargo clippy -- -D warnings
+          - check: test
+            command: cargo test
     steps:
       - uses: actions/checkout@v4
 
@@ -22,11 +28,4 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - if: matrix.check == 'fmt'
-        run: cargo fmt --check
-
-      - if: matrix.check == 'clippy'
-        run: cargo clippy -- -D warnings
-
-      - if: matrix.check == 'test'
-        run: cargo test
+      - run: ${{ matrix.command }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with a matrix job running `fmt`, `clippy`, and `test` in parallel on every push to `main` and all PRs
- Uses `dtolnay/rust-toolchain@stable` and `Swatinem/rust-cache@v2` for caching
- `fail-fast: false` so all three checks always run to completion

## Test plan

- [ ] Verify three parallel jobs (`fmt`, `clippy`, `test`) appear in the Actions tab after this PR is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)