### PR TITLE
Add Vault::backlinks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - `src/note.rs` — defines the `Note` struct
   - `src/link.rs` — parsing markdown/wiki/embedded links
   - `src/search.rs` — `find_note_paths()` for recursively finding `.md` files (public)
-  - `src/vault.rs` — defines the `Vault` struct
+  - `src/vault.rs` — defines the `Vault` struct; `notes()` loads all notes, `search()` returns a query builder, `backlinks(&Note)` returns notes linking to a given note
 
 ## Development
 

--- a/obsidian-core/src/vault.rs
+++ b/obsidian-core/src/vault.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
-use crate::{Note, search};
+use crate::{Link, LocatedLink, Note, search};
+use rayon::prelude::*;
 
 pub struct Vault {
     pub path: PathBuf,
@@ -45,6 +46,50 @@ impl Vault {
     /// Returns a [`SearchQuery`](search::SearchQuery) rooted at this vault's path.
     pub fn search(&self) -> search::SearchQuery {
         search::SearchQuery::new(&self.path)
+    }
+
+    /// Returns all notes in the vault that link to `target`, paired with the specific
+    /// [`LocatedLink`]s within each note that point to it.
+    ///
+    /// Only wiki links (`[[target]]`) and markdown links (`[text](target.md)`) are
+    /// considered. Embed links are excluded. Notes that fail to load are silently skipped.
+    pub fn backlinks(&self, target: &Note) -> Vec<(Note, Vec<LocatedLink>)> {
+        let target_stem = target
+            .path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_string());
+
+        let paths: Vec<_> = search::find_note_paths(&self.path).collect();
+        paths
+            .into_par_iter()
+            .filter_map(|path| {
+                let source = Note::from_path(&path).ok()?;
+                if source.path == target.path {
+                    return None;
+                }
+                let matching: Vec<LocatedLink> = source
+                    .links()
+                    .into_iter()
+                    .filter(|ll| match &ll.link {
+                        Link::Wiki {
+                            target: wiki_target,
+                            ..
+                        } => {
+                            wiki_target == &target.id
+                                || target_stem.as_deref().is_some_and(|s| wiki_target == s)
+                                || target.aliases.iter().any(|a| wiki_target == a)
+                        }
+                        _ => false,
+                    })
+                    .collect();
+                if matching.is_empty() {
+                    None
+                } else {
+                    Some((source, matching))
+                }
+            })
+            .collect()
     }
 }
 
@@ -129,5 +174,137 @@ mod tests {
             normalize_path(&PathBuf::from("/a/../../b")),
             PathBuf::from("/b")
         );
+    }
+
+    #[test]
+    fn backlinks_wiki_by_id() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "---\nid: my-id\n---\nTarget.").unwrap();
+        fs::write(dir.path().join("source.md"), "See [[my-id]].").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert_eq!(backlinks.len(), 1);
+        assert!(backlinks[0].0.path.ends_with("source.md"));
+        assert_eq!(backlinks[0].1.len(), 1);
+    }
+
+    #[test]
+    fn backlinks_wiki_by_stem_when_id_differs() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("my-note.md"),
+            "---\nid: custom-id\n---\nTarget.",
+        )
+        .unwrap();
+        fs::write(dir.path().join("source.md"), "See [[my-note]].").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("my-note.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert_eq!(backlinks.len(), 1);
+        assert!(backlinks[0].0.path.ends_with("source.md"));
+    }
+
+    #[test]
+    fn backlinks_wiki_by_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("target.md"),
+            "---\naliases: [t-alias]\n---\nTarget.",
+        )
+        .unwrap();
+        fs::write(dir.path().join("source.md"), "See [[t-alias]].").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert_eq!(backlinks.len(), 1);
+    }
+
+    #[test]
+    fn backlinks_wiki_by_title() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "# My Title\n\nContent.").unwrap();
+        fs::write(dir.path().join("source.md"), "See [[My Title]].").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert_eq!(backlinks.len(), 1);
+    }
+
+    #[test]
+    fn backlinks_wiki_with_heading_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "Target.").unwrap();
+        fs::write(dir.path().join("source.md"), "See [[target#section]].").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert_eq!(backlinks.len(), 1);
+    }
+
+    #[test]
+    fn backlinks_excludes_self() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "Self link: [[target]].").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert!(backlinks.is_empty());
+    }
+
+    #[test]
+    fn backlinks_excludes_notes_with_no_match() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "Target.").unwrap();
+        fs::write(dir.path().join("other.md"), "No links here.").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert!(backlinks.is_empty());
+    }
+
+    #[test]
+    fn backlinks_returns_all_matching_links_from_one_note() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "Target.").unwrap();
+        fs::write(
+            dir.path().join("source.md"),
+            "See [[target]] and also [[target]].",
+        )
+        .unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert_eq!(backlinks.len(), 1);
+        assert_eq!(backlinks[0].1.len(), 2);
+    }
+
+    #[test]
+    fn backlinks_no_match_on_unrelated_wiki_link() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "Target.").unwrap();
+        fs::write(dir.path().join("source.md"), "See [[other-note]].").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert!(backlinks.is_empty());
     }
 }

--- a/obsidian-core/src/vault.rs
+++ b/obsidian-core/src/vault.rs
@@ -80,6 +80,20 @@ impl Vault {
                                 || target_stem.as_deref().is_some_and(|s| wiki_target == s)
                                 || target.aliases.iter().any(|a| wiki_target == a)
                         }
+                        Link::Markdown { url, .. } => {
+                            if url.contains("://") || url.starts_with('/') {
+                                return false;
+                            }
+                            let url_path = match url.find('#') {
+                                Some(i) => &url[..i],
+                                None => url.as_str(),
+                            };
+                            if !url_path.ends_with(".md") {
+                                return false;
+                            }
+                            let source_dir = source.path.parent().unwrap_or(&source.path);
+                            normalize_path(&source_dir.join(url_path)) == target.path
+                        }
                         _ => false,
                     })
                     .collect();
@@ -300,6 +314,91 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("target.md"), "Target.").unwrap();
         fs::write(dir.path().join("source.md"), "See [[other-note]].").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert!(backlinks.is_empty());
+    }
+
+    #[test]
+    fn backlinks_markdown_relative_path() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "Target.").unwrap();
+        fs::write(dir.path().join("source.md"), "[link](target.md)").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert_eq!(backlinks.len(), 1);
+        assert!(backlinks[0].0.path.ends_with("source.md"));
+    }
+
+    #[test]
+    fn backlinks_markdown_fragment_stripped() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "Target.").unwrap();
+        fs::write(dir.path().join("source.md"), "[link](target.md#section)").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert_eq!(backlinks.len(), 1);
+    }
+
+    #[test]
+    fn backlinks_markdown_parent_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let subdir = dir.path().join("sub");
+        fs::create_dir(&subdir).unwrap();
+        fs::write(dir.path().join("target.md"), "Target.").unwrap();
+        fs::write(subdir.join("source.md"), "[link](../target.md)").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert_eq!(backlinks.len(), 1);
+    }
+
+    #[test]
+    fn backlinks_markdown_external_url_excluded() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "Target.").unwrap();
+        fs::write(
+            dir.path().join("source.md"),
+            "[link](https://example.com/target.md)",
+        )
+        .unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert!(backlinks.is_empty());
+    }
+
+    #[test]
+    fn backlinks_markdown_absolute_path_excluded() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "Target.").unwrap();
+        fs::write(dir.path().join("source.md"), "[link](/absolute/target.md)").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let target = Note::from_path(dir.path().join("target.md")).unwrap();
+        let backlinks = vault.backlinks(&target);
+
+        assert!(backlinks.is_empty());
+    }
+
+    #[test]
+    fn backlinks_markdown_extension_less_excluded() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("target.md"), "Target.").unwrap();
+        fs::write(dir.path().join("source.md"), "[link](target)").unwrap();
 
         let vault = Vault::open(dir.path()).unwrap();
         let target = Note::from_path(dir.path().join("target.md")).unwrap();

--- a/obsidian-core/src/vault.rs
+++ b/obsidian-core/src/vault.rs
@@ -6,6 +6,23 @@ pub struct Vault {
     pub path: PathBuf,
 }
 
+/// Normalizes a path by resolving `.` and `..` components without touching the filesystem.
+fn normalize_path(path: &std::path::Path) -> PathBuf {
+    let mut components: Vec<std::path::Component> = Vec::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if matches!(components.last(), Some(std::path::Component::Normal(_))) {
+                    components.pop();
+                }
+            }
+            c => components.push(c),
+        }
+    }
+    components.iter().collect()
+}
+
 impl Vault {
     /// Opens a vault at the given path, returning an error if the path does not exist or is not a
     /// directory.
@@ -79,5 +96,38 @@ mod tests {
         let vault = Vault::open(dir.path()).unwrap();
         let notes: Vec<Note> = vault.notes().into_iter().map(|r| r.unwrap()).collect();
         assert_eq!(notes.len(), 2);
+    }
+
+    #[test]
+    fn normalize_path_removes_dot() {
+        assert_eq!(
+            normalize_path(&PathBuf::from("/a/./b")),
+            PathBuf::from("/a/b")
+        );
+    }
+
+    #[test]
+    fn normalize_path_resolves_double_dot() {
+        assert_eq!(
+            normalize_path(&PathBuf::from("/a/b/../c")),
+            PathBuf::from("/a/c")
+        );
+    }
+
+    #[test]
+    fn normalize_path_deep_traversal() {
+        assert_eq!(
+            normalize_path(&PathBuf::from("/a/b/c/../../d")),
+            PathBuf::from("/a/d")
+        );
+    }
+
+    #[test]
+    fn normalize_path_traversal_beyond_root_stops_at_root() {
+        // /a/../../b: after processing, ends up as /b (the extra .. can't go above /)
+        assert_eq!(
+            normalize_path(&PathBuf::from("/a/../../b")),
+            PathBuf::from("/b")
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add `Vault::backlinks(&Note) -> Vec<(Note, Vec<LocatedLink>)>` that returns all notes in the vault containing links to a given target note, paired with the specific `LocatedLink`s within each note
- Add private `normalize_path` helper for lexicographic `.`/`..` path normalization without filesystem access
- Wiki links matched by note id, file stem, and aliases (which include title); markdown links matched by resolved relative path with fragment stripping; embed links excluded

## Test Plan

- [ ] `cargo test` — 79 tests, all passing
- [ ] `cargo clippy` — no warnings
- [ ] Wiki matching: by id, file stem (when frontmatter id differs), alias, title, heading suffix
- [ ] Markdown matching: relative path, fragment stripping, `../` traversal
- [ ] Exclusions: self-backlinks, external URLs, absolute paths, extension-less URLs