### PR TITLE
Add Note::write() with atomic writes and sorted frontmatter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,8 +240,10 @@ version = "0.1.0"
 dependencies = [
  "globset",
  "gray_matter",
+ "indexmap",
  "rayon",
  "regex",
+ "serde_yaml",
  "tempfile",
  "walkdir",
 ]
@@ -349,6 +351,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +415,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +482,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "walkdir"

--- a/obsidian-core/Cargo.toml
+++ b/obsidian-core/Cargo.toml
@@ -10,9 +10,11 @@ path = "src/lib.rs"
 [dependencies]
 globset = "0.4"
 gray_matter = "0.3.2"
+indexmap = "2"
 rayon = "1"
 regex = "1"
+serde_yaml = "0.9"
+tempfile = "3"
 walkdir = "2"
 
 [dev-dependencies]
-tempfile = "3"

--- a/obsidian-core/src/note.rs
+++ b/obsidian-core/src/note.rs
@@ -1,7 +1,8 @@
-use std::collections::HashMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use gray_matter::{Matter, Pod, engine::YAML};
+use indexmap::IndexMap;
 
 pub struct Note {
     pub path: PathBuf,
@@ -10,7 +11,7 @@ pub struct Note {
     pub aliases: Vec<String>,
     pub tags: Vec<String>,
     pub content: String,
-    pub frontmatter: Option<HashMap<String, Pod>>,
+    pub frontmatter: Option<IndexMap<String, Pod>>,
     /// Number of lines occupied by the frontmatter block (including delimiters).
     /// Used to offset link locations so they reflect positions in the original file.
     pub frontmatter_line_count: usize,
@@ -22,7 +23,14 @@ impl Note {
         let matter = Matter::<YAML>::new();
         let (body, frontmatter) = match matter.parse(content) {
             Ok(parsed) => {
-                let fm = parsed.data.and_then(|pod: Pod| pod.as_hashmap().ok());
+                let fm = parsed
+                    .data
+                    .and_then(|pod: Pod| pod.as_hashmap().ok())
+                    .map(|hm| {
+                        let mut entries: Vec<_> = hm.into_iter().collect();
+                        entries.sort_by(|a, b| a.0.cmp(&b.0));
+                        entries.into_iter().collect::<IndexMap<_, _>>()
+                    });
                 (parsed.content, fm)
             }
             Err(_) => (content.to_string(), None),
@@ -93,6 +101,56 @@ impl Note {
     pub fn from_path(path: impl AsRef<Path>) -> Result<Self, std::io::Error> {
         let content = std::fs::read_to_string(&path)?;
         Ok(Self::parse(path, &content))
+    }
+
+    /// Atomically write the note to `self.path`, including serialized frontmatter.
+    ///
+    /// Frontmatter keys are serialized in alphabetical order. Because the underlying
+    /// YAML parser does not preserve insertion order, keys parsed from disk are sorted
+    /// on load, so round-trips produce deterministic output.
+    pub fn write(&self) -> Result<(), std::io::Error> {
+        let file_content = self
+            .to_file_content()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        let parent = self.path.parent().unwrap_or_else(|| Path::new("."));
+        let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+        tmp.write_all(file_content.as_bytes())?;
+        tmp.persist(&self.path).map_err(|e| e.error)?;
+        Ok(())
+    }
+
+    fn to_file_content(&self) -> Result<String, serde_yaml::Error> {
+        match &self.frontmatter {
+            None => Ok(self.content.clone()),
+            Some(fm) => {
+                let mapping: serde_yaml::Mapping = fm
+                    .iter()
+                    .map(|(k, v)| (serde_yaml::Value::String(k.clone()), pod_to_yaml_value(v)))
+                    .collect();
+                let yaml = serde_yaml::to_string(&mapping)?;
+                // serde_yaml may or may not emit a leading "---\n"; strip it so we
+                // control the delimiters ourselves.
+                let yaml = yaml.strip_prefix("---\n").unwrap_or(&yaml);
+                Ok(format!("---\n{}---\n{}", yaml, self.content))
+            }
+        }
+    }
+}
+
+fn pod_to_yaml_value(pod: &Pod) -> serde_yaml::Value {
+    match pod {
+        Pod::Null => serde_yaml::Value::Null,
+        Pod::String(s) => serde_yaml::Value::String(s.clone()),
+        Pod::Integer(i) => serde_yaml::Value::Number((*i).into()),
+        Pod::Float(f) => serde_yaml::Value::Number(serde_yaml::Number::from(*f)),
+        Pod::Boolean(b) => serde_yaml::Value::Bool(*b),
+        Pod::Array(arr) => serde_yaml::Value::Sequence(arr.iter().map(pod_to_yaml_value).collect()),
+        Pod::Hash(map) => serde_yaml::Value::Mapping(
+            map.iter()
+                .map(|(k, v)| (serde_yaml::Value::String(k.clone()), pod_to_yaml_value(v)))
+                .collect(),
+        ),
     }
 }
 
@@ -228,6 +286,50 @@ mod tests {
     fn tags_empty_when_absent() {
         let note = Note::parse("/vault/note.md", "No frontmatter here.");
         assert!(note.tags.is_empty());
+    }
+
+    #[test]
+    fn write_round_trips_note_without_frontmatter() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let original = "Just some plain content.";
+        std::fs::write(tmp.path(), original).unwrap();
+
+        let note = Note::from_path(tmp.path()).unwrap();
+        note.write().unwrap();
+
+        let on_disk = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(on_disk, original);
+    }
+
+    #[test]
+    fn write_round_trips_note_with_frontmatter() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let original = "---\ntitle: My Note\n---\n\nBody text.";
+        std::fs::write(tmp.path(), original).unwrap();
+
+        let note = Note::from_path(tmp.path()).unwrap();
+        note.write().unwrap();
+
+        // Re-parse to verify the on-disk content is valid and retains key fields.
+        let reparsed = Note::from_path(tmp.path()).unwrap();
+        assert_eq!(reparsed.title.as_deref(), Some("My Note"));
+        assert_eq!(reparsed.content.trim(), "Body text.");
+    }
+
+    #[test]
+    fn write_reflects_frontmatter_mutation() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "---\ntitle: Old Title\n---\n\nContent.").unwrap();
+
+        let mut note = Note::from_path(tmp.path()).unwrap();
+        note.frontmatter
+            .as_mut()
+            .unwrap()
+            .insert("title".to_string(), Pod::String("New Title".to_string()));
+        note.write().unwrap();
+
+        let reparsed = Note::from_path(tmp.path()).unwrap();
+        assert_eq!(reparsed.title.as_deref(), Some("New Title"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `Note::write(&self) -> Result<(), io::Error>` which serializes frontmatter to YAML and atomically writes to `self.path` (temp file in same directory + rename)
- Switches `frontmatter` from `HashMap<String, Pod>` to `IndexMap<String, Pod>`; keys are sorted alphabetically at parse time so round-trips produce deterministic output
- Adds `serde_yaml` (for `Pod` → YAML serialization) and `indexmap` as dependencies; promotes `tempfile` from dev-dependency to regular dependency

## Notes

The underlying YAML parser (`gray_matter`) uses `HashMap` internally, so key insertion order from the original file is not preserved. Sorting at parse time makes output deterministic — keys will always be emitted alphabetically on write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)