### PR TITLE
Add obsidian-cli binary crate with search and backlinks subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`obsidian.rs` is a Rust library for working with Obsidian vaults. It is structured as a Cargo workspace with sub-crates for various features:
+`obsidian.rs` is a Rust library and CLI for working with Obsidian vaults. It is structured as a Cargo workspace with sub-crates for various features:
 - `obsidian-core` (crate name: `obsidian_core`): core API used by the other sub-crates.
+- `obsidian-cli` (binary name: `obsidian`): command-line interface exposing `search` and `backlinks` subcommands.
 
 ## Workspace Structure
 
@@ -16,6 +17,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - `src/link.rs` — parsing markdown/wiki/embedded links
   - `src/search.rs` — `find_note_paths()` for recursively finding `.md` files (public)
   - `src/vault.rs` — defines the `Vault` struct; `notes()` loads all notes, `search()` returns a query builder, `backlinks(&Note)` returns notes linking to a given note
+- `obsidian-cli/` — the CLI binary crate
+  - `src/main.rs` — entry point, subcommand dispatch
+  - `src/args.rs` — clap argument structs and enums
+  - `src/output.rs` — plain and JSON rendering
+  - `src/error.rs` — `CliError` type
+  - `tests/cli.rs` — integration tests via `assert_cmd`
 
 ## Development
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,6 +72,27 @@ name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
@@ -36,6 +107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -44,6 +116,52 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "crossbeam-deque"
@@ -69,6 +187,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "either"
@@ -106,6 +230,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -199,6 +332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +374,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "obsidian-cli"
+version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "clap",
+ "obsidian-core",
+ "predicates",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "obsidian-core"
 version = "0.1.0"
 dependencies = [
@@ -253,6 +420,42 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "prettyplease"
@@ -428,6 +631,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +659,12 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
@@ -488,6 +703,21 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,5 @@
 resolver = "3"
 members = [
     "obsidian-core",
+    "obsidian-cli",
 ]

--- a/obsidian-cli/Cargo.toml
+++ b/obsidian-cli/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "obsidian-cli"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "obsidian"
+path = "src/main.rs"
+
+[dependencies]
+obsidian-core = { path = "../obsidian-core" }
+clap = { version = "4", features = ["derive", "env"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+serde_json = "1"
+tempfile = "3"

--- a/obsidian-cli/src/args.rs
+++ b/obsidian-cli/src/args.rs
@@ -1,0 +1,64 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand, ValueEnum};
+
+#[derive(Parser)]
+#[command(name = "obsidian", about = "Query and navigate Obsidian vaults")]
+pub struct Cli {
+    /// Path to the vault directory. Defaults to current directory.
+    #[arg(
+        long,
+        short = 'v',
+        global = true,
+        env = "OBSIDIAN_VAULT",
+        default_value = "."
+    )]
+    pub vault: PathBuf,
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Search for notes in the vault
+    Search(SearchArgs),
+    /// Find notes that link to a given note
+    Backlinks(BacklinksArgs),
+}
+
+#[derive(clap::Args)]
+pub struct SearchArgs {
+    /// Filter by tag (AND semantics, repeatable)
+    #[arg(long, short = 't')]
+    pub tag: Vec<String>,
+    /// Filter by title substring (case-insensitive)
+    #[arg(long)]
+    pub title: Option<String>,
+    /// Filter by glob pattern (OR semantics, repeatable)
+    #[arg(long, short = 'g')]
+    pub glob: Vec<String>,
+    /// Filter by content substring (AND semantics, repeatable)
+    #[arg(long, short = 'c')]
+    pub content: Vec<String>,
+    /// Filter by content regex
+    #[arg(long, short = 'r')]
+    pub regex: Option<String>,
+    /// Output format
+    #[arg(long, short = 'f', default_value = "plain")]
+    pub format: OutputFormat,
+}
+
+#[derive(clap::Args)]
+pub struct BacklinksArgs {
+    /// Path to the note (resolved relative to current directory)
+    pub note: PathBuf,
+    /// Output format
+    #[arg(long, short = 'f', default_value = "plain")]
+    pub format: OutputFormat,
+}
+
+#[derive(Clone, ValueEnum)]
+pub enum OutputFormat {
+    Plain,
+    Json,
+}

--- a/obsidian-cli/src/error.rs
+++ b/obsidian-cli/src/error.rs
@@ -1,0 +1,31 @@
+use std::path::PathBuf;
+
+use obsidian_core::SearchError;
+
+pub enum CliError {
+    Io(std::io::Error),
+    Search(SearchError),
+    NoteNotFound(PathBuf),
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CliError::Io(e) => write!(f, "{e}"),
+            CliError::Search(e) => write!(f, "{e}"),
+            CliError::NoteNotFound(path) => write!(f, "note not found: {}", path.display()),
+        }
+    }
+}
+
+impl From<std::io::Error> for CliError {
+    fn from(e: std::io::Error) -> Self {
+        CliError::Io(e)
+    }
+}
+
+impl From<SearchError> for CliError {
+    fn from(e: SearchError) -> Self {
+        CliError::Search(e)
+    }
+}

--- a/obsidian-cli/src/main.rs
+++ b/obsidian-cli/src/main.rs
@@ -1,0 +1,81 @@
+mod args;
+mod error;
+mod output;
+
+use std::env::current_dir;
+use std::process;
+
+use clap::Parser;
+use obsidian_core::{Note, Vault};
+
+use args::{BacklinksArgs, Cli, Command, OutputFormat, SearchArgs};
+use error::CliError;
+
+fn cmd_search(vault: Vault, args: SearchArgs) -> Result<(), CliError> {
+    let mut query = vault.search();
+    for tag in &args.tag {
+        query = query.has_tag(tag);
+    }
+    for glob in &args.glob {
+        query = query.glob(glob);
+    }
+    for s in &args.content {
+        query = query.content_contains(s);
+    }
+    if let Some(t) = &args.title {
+        query = query.title_contains(t);
+    }
+    if let Some(r) = &args.regex {
+        query = query.content_matches(r);
+    }
+
+    let results = query.execute()?;
+    let mut notes: Vec<Note> = results.into_iter().filter_map(|r| r.ok()).collect();
+    notes.sort_by(|a, b| a.path.cmp(&b.path));
+
+    match args.format {
+        OutputFormat::Plain => output::print_search_plain(&notes, &vault.path),
+        OutputFormat::Json => output::print_search_json(&notes, &vault.path),
+    }
+    Ok(())
+}
+
+fn cmd_backlinks(vault: Vault, args: BacklinksArgs) -> Result<(), CliError> {
+    let note_path = if args.note.is_absolute() {
+        args.note.clone()
+    } else {
+        current_dir()?.join(&args.note)
+    };
+    if !note_path.exists() {
+        return Err(CliError::NoteNotFound(note_path));
+    }
+
+    let note = Note::from_path(&note_path)?;
+    let mut results = vault.backlinks(&note);
+    results.sort_by(|(a, _), (b, _)| a.path.cmp(&b.path));
+
+    match args.format {
+        OutputFormat::Plain => output::print_backlinks_plain(&results, &vault.path),
+        OutputFormat::Json => output::print_backlinks_json(&results, &vault.path),
+    }
+    Ok(())
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let vault = match Vault::open(&cli.vault) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            process::exit(1);
+        }
+    };
+    let result = match cli.command {
+        Command::Search(args) => cmd_search(vault, args),
+        Command::Backlinks(args) => cmd_backlinks(vault, args),
+    };
+    if let Err(e) = result {
+        eprintln!("error: {e}");
+        process::exit(1);
+    }
+}

--- a/obsidian-cli/src/output.rs
+++ b/obsidian-cli/src/output.rs
@@ -1,0 +1,90 @@
+use std::path::Path;
+
+use obsidian_core::{Link, LocatedLink, Note};
+use serde::Serialize;
+
+pub fn print_search_plain(notes: &[Note], vault_path: &Path) {
+    for note in notes {
+        let rel = note.path.strip_prefix(vault_path).unwrap_or(&note.path);
+        println!("{}", rel.display());
+    }
+}
+
+#[derive(Serialize)]
+struct NoteJson<'a> {
+    path: String,
+    id: &'a str,
+    title: Option<&'a str>,
+    tags: &'a [String],
+}
+
+pub fn print_search_json(notes: &[Note], vault_path: &Path) {
+    let items: Vec<NoteJson> = notes
+        .iter()
+        .map(|n| {
+            let rel = n.path.strip_prefix(vault_path).unwrap_or(&n.path);
+            NoteJson {
+                path: rel.display().to_string(),
+                id: &n.id,
+                title: n.title.as_deref(),
+                tags: &n.tags,
+            }
+        })
+        .collect();
+    println!("{}", serde_json::to_string(&items).unwrap());
+}
+
+pub fn print_backlinks_plain(results: &[(Note, Vec<LocatedLink>)], vault_path: &Path) {
+    for (note, _) in results {
+        let rel = note.path.strip_prefix(vault_path).unwrap_or(&note.path);
+        println!("{}", rel.display());
+    }
+}
+
+#[derive(Serialize)]
+struct LinkJson {
+    kind: &'static str,
+    target: String,
+    line: usize,
+    col_start: usize,
+    col_end: usize,
+}
+
+#[derive(Serialize)]
+struct BacklinkJson<'a> {
+    source_path: String,
+    source_id: &'a str,
+    links: Vec<LinkJson>,
+}
+
+pub fn print_backlinks_json(results: &[(Note, Vec<LocatedLink>)], vault_path: &Path) {
+    let items: Vec<BacklinkJson> = results
+        .iter()
+        .map(|(note, links)| {
+            let rel = note.path.strip_prefix(vault_path).unwrap_or(&note.path);
+            let link_jsons = links
+                .iter()
+                .map(|ll| {
+                    let (kind, target) = match &ll.link {
+                        Link::Wiki { target, .. } => ("wiki", target.clone()),
+                        Link::Markdown { url, .. } => ("markdown", url.clone()),
+                        Link::Embed { target, .. } => ("embed", target.clone()),
+                    };
+                    LinkJson {
+                        kind,
+                        target,
+                        line: ll.location.line,
+                        col_start: ll.location.col_start,
+                        col_end: ll.location.col_end,
+                    }
+                })
+                .collect();
+            BacklinkJson {
+                source_path: rel.display().to_string(),
+                source_id: &note.id,
+                links: link_jsons,
+            }
+        })
+        .collect();
+    println!("{}", serde_json::to_string(&items).unwrap());
+}

--- a/obsidian-cli/tests/cli.rs
+++ b/obsidian-cli/tests/cli.rs
@@ -1,0 +1,310 @@
+use std::fs;
+use std::path::Path;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn obsidian() -> Command {
+    Command::cargo_bin("obsidian").unwrap()
+}
+
+fn make_vault() -> TempDir {
+    tempfile::tempdir().unwrap()
+}
+
+fn write_note(dir: &Path, name: &str, content: &str) {
+    let path = dir.join(name);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, content).unwrap();
+}
+
+#[test]
+fn search_no_filters_returns_all_notes() {
+    let vault = make_vault();
+    write_note(vault.path(), "a.md", "Note A.");
+    write_note(vault.path(), "b.md", "Note B.");
+    obsidian()
+        .args(["--vault", vault.path().to_str().unwrap(), "search"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("a.md"))
+        .stdout(predicate::str::contains("b.md"));
+}
+
+#[test]
+fn search_tag_filter() {
+    let vault = make_vault();
+    write_note(
+        vault.path(),
+        "tagged.md",
+        "---\ntags: [rust]\n---\nContent.",
+    );
+    write_note(vault.path(), "untagged.md", "No tags.");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "search",
+            "--tag",
+            "rust",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("tagged.md"))
+        .stdout(predicate::str::contains("untagged.md").not());
+}
+
+#[test]
+fn search_tag_and_semantics() {
+    let vault = make_vault();
+    write_note(
+        vault.path(),
+        "both.md",
+        "---\ntags: [rust, obsidian]\n---\nContent.",
+    );
+    write_note(vault.path(), "one.md", "---\ntags: [rust]\n---\nContent.");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "search",
+            "--tag",
+            "rust",
+            "--tag",
+            "obsidian",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("both.md"))
+        .stdout(predicate::str::contains("one.md").not());
+}
+
+#[test]
+fn search_glob_filter() {
+    let vault = make_vault();
+    write_note(vault.path(), "notes/a.md", "Note A.");
+    write_note(vault.path(), "journal/b.md", "Note B.");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "search",
+            "--glob",
+            "notes/**",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("notes/a.md"))
+        .stdout(predicate::str::contains("journal/b.md").not());
+}
+
+#[test]
+fn search_content_filter() {
+    let vault = make_vault();
+    write_note(vault.path(), "match.md", "This mentions ferris.");
+    write_note(vault.path(), "no-match.md", "Nothing special.");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "search",
+            "--content",
+            "ferris",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("match.md"))
+        .stdout(predicate::str::contains("no-match.md").not());
+}
+
+#[test]
+fn search_regex_filter() {
+    let vault = make_vault();
+    write_note(vault.path(), "match.md", "Score: 42 points.");
+    write_note(vault.path(), "no-match.md", "No numbers here.");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "search",
+            "--regex",
+            r"\d+",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("match.md"))
+        .stdout(predicate::str::contains("no-match.md").not());
+}
+
+#[test]
+fn search_invalid_regex_exits_with_error() {
+    let vault = make_vault();
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "search",
+            "--regex",
+            "[invalid",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error"));
+}
+
+#[test]
+fn search_json_format() {
+    let vault = make_vault();
+    write_note(vault.path(), "note.md", "---\ntags: [rust]\n---\nContent.");
+    let output = obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "search",
+            "--format",
+            "json",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(output).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+    assert!(v.is_array());
+    assert_eq!(v.as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn search_nonexistent_vault_exits_with_error() {
+    obsidian()
+        .args(["--vault", "/nonexistent/vault/path", "search"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error"));
+}
+
+#[test]
+fn search_output_is_sorted() {
+    let vault = make_vault();
+    write_note(vault.path(), "z.md", "Note Z.");
+    write_note(vault.path(), "a.md", "Note A.");
+    write_note(vault.path(), "m.md", "Note M.");
+    let output = obsidian()
+        .args(["--vault", vault.path().to_str().unwrap(), "search"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(output).unwrap();
+    let lines: Vec<&str> = s.lines().collect();
+    let mut sorted = lines.clone();
+    sorted.sort();
+    assert_eq!(lines, sorted);
+}
+
+#[test]
+fn backlinks_no_links_returns_empty() {
+    let vault = make_vault();
+    write_note(vault.path(), "target.md", "Target.");
+    write_note(vault.path(), "other.md", "No links.");
+    let note_path = vault.path().join("target.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "backlinks",
+            note_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn backlinks_finds_wiki_links() {
+    let vault = make_vault();
+    write_note(vault.path(), "target.md", "Target.");
+    write_note(vault.path(), "source.md", "See [[target]].");
+    let note_path = vault.path().join("target.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "backlinks",
+            note_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("source.md"));
+}
+
+#[test]
+fn backlinks_finds_markdown_links() {
+    let vault = make_vault();
+    write_note(vault.path(), "target.md", "Target.");
+    write_note(vault.path(), "source.md", "[link](target.md)");
+    let note_path = vault.path().join("target.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "backlinks",
+            note_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("source.md"));
+}
+
+#[test]
+fn backlinks_json_format() {
+    let vault = make_vault();
+    write_note(vault.path(), "target.md", "Target.");
+    write_note(vault.path(), "source.md", "See [[target]].");
+    let note_path = vault.path().join("target.md");
+    let output = obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "backlinks",
+            "--format",
+            "json",
+            note_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(output).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+    assert!(v.is_array());
+    let arr = v.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    let item = &arr[0];
+    assert!(item["source_path"].as_str().unwrap().contains("source.md"));
+    assert!(item["links"].is_array());
+    let links = item["links"].as_array().unwrap();
+    assert_eq!(links.len(), 1);
+    assert_eq!(links[0]["kind"].as_str().unwrap(), "wiki");
+}
+
+#[test]
+fn backlinks_nonexistent_note_exits_with_error() {
+    let vault = make_vault();
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "backlinks",
+            "/nonexistent/note.md",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error"));
+}


### PR DESCRIPTION
## Summary

- Adds new `obsidian-cli` workspace member (binary name: `obsidian`) exposing the `obsidian-core` API from the command line
- `search` subcommand supports `--tag` (AND), `--glob` (OR), `--content` (AND), `--title`, `--regex` filters with `--format plain|json` output
- `backlinks` subcommand finds notes linking to a given note, with `--format plain|json` output; note path is resolved relative to cwd for natural CLI ergonomics

## Test Plan

- [x] 15 integration tests via `assert_cmd` covering all filters, error cases, JSON output, and sort determinism
- [x] All 97 workspace tests pass (`cargo test`)
- [x] No clippy warnings (`cargo clippy`)
- [x] Formatted (`cargo fmt`)