### PR TITLE
Add color to plain text CLI output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -221,6 +221,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,7 +289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -498,6 +508,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "color-eyre",
+ "colored",
  "obsidian-core",
  "predicates",
  "serde",
@@ -673,7 +684,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -789,7 +800,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -995,7 +1006,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1006,12 +1017,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/obsidian-cli/Cargo.toml
+++ b/obsidian-cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 obsidian-core = { path = "../obsidian-core" }
 clap = { version = "4", features = ["derive", "env"] }
 color-eyre = "0.6"
+colored = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/obsidian-cli/src/args.rs
+++ b/obsidian-cli/src/args.rs
@@ -8,6 +8,12 @@ pub struct Cli {
     /// Path to the vault directory. Defaults to current directory.
     #[arg(long, short = 'v', global = true, env = "OBSIDIAN_VAULT", default_value = ".")]
     pub vault: PathBuf,
+    /// Force color output even when not writing to a TTY
+    #[arg(long, global = true)]
+    pub color: bool,
+    /// Disable color output
+    #[arg(long, global = true)]
+    pub no_color: bool,
     #[command(subcommand)]
     pub command: Command,
 }

--- a/obsidian-cli/src/main.rs
+++ b/obsidian-cli/src/main.rs
@@ -156,6 +156,13 @@ fn cmd_tags_list(vault: Vault, args: TagsListArgs) -> eyre::Result<()> {
 fn main() -> eyre::Result<()> {
     color_eyre::install()?;
     let cli = Cli::parse();
+    if cli.color && cli.no_color {
+        eyre::bail!("--color and --no-color are mutually exclusive");
+    } else if cli.color {
+        colored::control::set_override(true);
+    } else if cli.no_color {
+        colored::control::set_override(false);
+    }
     let vault = Vault::open(&cli.vault)?;
     match cli.command {
         Command::Search(args) => cmd_search(vault, args),

--- a/obsidian-cli/src/main.rs
+++ b/obsidian-cli/src/main.rs
@@ -5,6 +5,7 @@ use std::env::current_dir;
 
 use clap::Parser;
 use color_eyre::eyre;
+use colored::Colorize;
 use obsidian_core::{LocatedTag, Note, Vault};
 
 use args::{BacklinksArgs, Cli, Command, OutputFormat, RenameArgs, SearchArgs, TagsListArgs, TagsSearchArgs};
@@ -95,7 +96,7 @@ fn cmd_rename(vault: Vault, args: RenameArgs) -> eyre::Result<()> {
     } else {
         let renamed = vault.rename(&note, &new_path)?;
         let rel = renamed.path.strip_prefix(&vault.path).unwrap_or(&renamed.path);
-        println!("{}", rel.display());
+        println!("{}", rel.display().to_string().cyan());
     }
     Ok(())
 }

--- a/obsidian-cli/src/output.rs
+++ b/obsidian-cli/src/output.rs
@@ -1,12 +1,13 @@
 use std::path::Path;
 
+use colored::Colorize;
 use obsidian_core::{Link, LocatedLink, LocatedTag, Note, RenamePreview};
 use serde::Serialize;
 
 pub fn print_search_plain(notes: &[Note], vault_path: &Path) {
     for note in notes {
         let rel = note.path.strip_prefix(vault_path).unwrap_or(&note.path);
-        println!("{}", rel.display());
+        println!("{}", rel.display().to_string().cyan());
     }
 }
 
@@ -37,7 +38,7 @@ pub fn print_search_json(notes: &[Note], vault_path: &Path) {
 pub fn print_backlinks_plain(results: &[(Note, Vec<LocatedLink>)], vault_path: &Path) {
     for (note, _) in results {
         let rel = note.path.strip_prefix(vault_path).unwrap_or(&note.path);
-        println!("{}", rel.display());
+        println!("{}", rel.display().to_string().cyan());
     }
 }
 
@@ -59,14 +60,16 @@ struct BacklinkJson<'a> {
 
 pub fn print_rename_preview_plain(preview: &RenamePreview, vault_path: &Path) {
     let rel_new = preview.new_path.strip_prefix(vault_path).unwrap_or(&preview.new_path);
-    println!("{}", rel_new.display());
+    println!("{}", rel_new.display().to_string().cyan().bold());
     for (path, count) in &preview.updated_notes {
         let rel = path.strip_prefix(vault_path).unwrap_or(path);
+        let link_word = if *count == 1 { "link" } else { "links" };
+        let count_str = format!("({} {})", count, link_word).dimmed();
         println!(
-            " ➡️update: {} ({} link{})",
-            rel.display(),
-            count,
-            if *count == 1 { "" } else { "s" }
+            " {} {} {}",
+            "➡️update:".green(),
+            rel.display().to_string().cyan(),
+            count_str
         );
     }
 }
@@ -108,12 +111,14 @@ pub fn print_rename_preview_json(preview: &RenamePreview, vault_path: &Path) {
 pub fn print_tags_search_plain(results: &[(Note, Vec<String>, Vec<LocatedTag>)], vault_path: &Path) {
     for (note, fm_tags, inline_tags) in results {
         let rel = note.path.strip_prefix(vault_path).unwrap_or(&note.path);
-        println!("{}", rel.display());
+        println!("{}", rel.display().to_string().cyan());
         if !fm_tags.is_empty() {
-            println!("  [frontmatter] {}", fm_tags.join(", "));
+            let tags_colored: Vec<String> = fm_tags.iter().map(|t| t.yellow().to_string()).collect();
+            println!("  {} {}", "[frontmatter]".dimmed(), tags_colored.join(", "));
         }
         for lt in inline_tags {
-            println!("  [{}:{}] #{}", lt.location.line, lt.location.col_start, lt.tag);
+            let marker = format!("[{}:{}]", lt.location.line, lt.location.col_start);
+            println!("  {} #{}", marker.dimmed(), lt.tag.yellow());
         }
     }
 }
@@ -158,7 +163,7 @@ pub fn print_tags_search_json(results: &[(Note, Vec<String>, Vec<LocatedTag>)], 
 
 pub fn print_tags_list_plain(tags: &[String]) {
     for tag in tags {
-        println!("{}", tag);
+        println!("{}", tag.yellow());
     }
 }
 

--- a/obsidian-cli/tests/cli.rs
+++ b/obsidian-cli/tests/cli.rs
@@ -851,7 +851,13 @@ fn color_and_no_color_are_mutually_exclusive() {
     let vault = make_vault();
     write_note(vault.path(), "a.md", "Note A.");
     obsidian()
-        .args(["--vault", vault.path().to_str().unwrap(), "--color", "--no-color", "search"])
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "--color",
+            "--no-color",
+            "search",
+        ])
         .assert()
         .failure()
         .stderr(predicate::str::contains("--color and --no-color"));

--- a/obsidian-cli/tests/cli.rs
+++ b/obsidian-cli/tests/cli.rs
@@ -845,3 +845,14 @@ fn tags_search_no_tags_arg_exits_with_error() {
         .assert()
         .failure();
 }
+
+#[test]
+fn color_and_no_color_are_mutually_exclusive() {
+    let vault = make_vault();
+    write_note(vault.path(), "a.md", "Note A.");
+    obsidian()
+        .args(["--vault", vault.path().to_str().unwrap(), "--color", "--no-color", "search"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--color and --no-color"));
+}


### PR DESCRIPTION
## Summary

- Add `--color` / `--no-color` global flags; auto-detects TTY by default
- Passing both flags produces an error (`--color and --no-color are mutually exclusive`)
- Color scheme for plain text mode: paths in cyan, tags in yellow, location markers dimmed, rename preview prefix in green, link counts dimmed, rename destination in cyan+bold
- JSON output is unaffected

## Test Plan

- [ ] Run `cargo test` — all tests pass (colors are suppressed in piped/non-TTY mode so existing assertions are unaffected)
- [ ] Manual: `obsidian search` shows cyan paths; `obsidian tags search <tag>` shows yellow tags; `obsidian rename --dry-run` shows styled preview
- [ ] Manual: `obsidian --no-color search` produces plain output; `obsidian --color search` forces color even when piped
- [ ] Manual: `obsidian --color --no-color search` exits non-zero with error message containing `--color and --no-color`

🤖 Generated with [Claude Code](https://claude.com/claude-code)