### PR TITLE
add obsidian note merge command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 `obsidian.rs` is a Rust library and CLI for working with Obsidian vaults. It is structured as a Cargo workspace with sub-crates for various features:
 - `obsidian-core` (crate name: `obsidian_core`): core API used by the other sub-crates.
-- `obsidian-cli` (binary name: `obsidian`): command-line interface exposing `search`, `note`, `tags`, and `check` commands.
+- `obsidian-cli` (binary name: `obsidian`): command-line interface exposing `search`, `note`, `tags`, and `check` commands. The `note` subcommand supports `backlinks`, `merge`, `rename`, and `update`.
 
 ## Workspace Structure
 
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - `src/note.rs` — defines the `Note` struct
   - `src/link.rs` — parsing markdown/wiki/embedded links
   - `src/search.rs` — `find_note_paths()` for recursively finding `.md` files (public)
-  - `src/vault.rs` — defines the `Vault` struct; `notes()` loads all notes, `search()` returns a query builder, `backlinks(&Note)` returns notes linking to a given note, `rename(&Note, new_stem)` renames a note and updates all backlinks
+  - `src/vault.rs` — defines the `Vault` struct; `notes()` loads all notes, `search()` returns a query builder, `backlinks(&Note)` returns notes linking to a given note, `rename(&Note, new_path)` renames a note and updates all backlinks, `merge(&[Note], dest_path)` merges multiple notes into a destination and updates all backlinks
 - `obsidian-cli/` — the CLI binary crate
   - `src/main.rs` — entry point, subcommand dispatch
   - `src/args.rs` — clap argument structs and enums

--- a/obsidian-cli/src/args.rs
+++ b/obsidian-cli/src/args.rs
@@ -99,6 +99,22 @@ pub struct RenameArgs {
 }
 
 #[derive(clap::Args)]
+pub struct MergeArgs {
+    /// One or more source notes followed by the destination note.
+    /// All paths are resolved relative to the current directory.
+    /// The last path is the destination; all preceding paths are sources.
+    /// Sources are merged into the destination (which is created if it doesn't exist) and deleted.
+    #[arg(required = true, num_args = 2..)]
+    pub paths: Vec<PathBuf>,
+    /// Preview what would change without modifying any files
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Output format
+    #[arg(long, short = 'f', default_value = "plain")]
+    pub format: OutputFormat,
+}
+
+#[derive(clap::Args)]
 pub struct NoteArgs {
     #[command(subcommand)]
     pub subcommand: NoteCommand,
@@ -108,6 +124,8 @@ pub struct NoteArgs {
 pub enum NoteCommand {
     /// Find notes that link to a given note
     Backlinks(BacklinksArgs),
+    /// Merge two or more notes into a single destination note
+    Merge(MergeArgs),
     /// Rename a note and update all backlinks
     Rename(RenameArgs),
     /// Update fields of a note

--- a/obsidian-cli/src/args.rs
+++ b/obsidian-cli/src/args.rs
@@ -104,7 +104,7 @@ pub struct MergeArgs {
     /// All paths are resolved relative to the current directory.
     /// The last path is the destination; all preceding paths are sources.
     /// Sources are merged into the destination (which is created if it doesn't exist) and deleted.
-    #[arg(required = true, num_args = 2..)]
+    #[arg(name = "PATH", required = true, num_args = 2..)]
     pub paths: Vec<PathBuf>,
     /// Preview what would change without modifying any files
     #[arg(long)]

--- a/obsidian-cli/src/main.rs
+++ b/obsidian-cli/src/main.rs
@@ -30,6 +30,7 @@ fn main() -> eyre::Result<()> {
         Command::Search(args) => search::cmd_search(vault, args),
         Command::Note(note_args) => match note_args.subcommand {
             args::NoteCommand::Backlinks(args) => note::cmd_backlinks(vault, args),
+            args::NoteCommand::Merge(args) => note::cmd_merge(vault, args),
             args::NoteCommand::Rename(args) => note::cmd_rename(vault, args),
             args::NoteCommand::Update(args) => note::cmd_note_update(vault, args),
         },

--- a/obsidian-cli/src/note.rs
+++ b/obsidian-cli/src/note.rs
@@ -4,9 +4,53 @@ use color_eyre::eyre;
 use colored::Colorize;
 use obsidian_core::{Note, Vault};
 
-use crate::args::{BacklinksArgs, OutputFormat, RenameArgs, UpdateArgs};
+use crate::args::{BacklinksArgs, MergeArgs, OutputFormat, RenameArgs, UpdateArgs};
 use crate::output;
 use crate::utils::{resolve_note_path, sort_notes_by};
+
+pub fn cmd_merge(vault: Vault, args: MergeArgs) -> eyre::Result<()> {
+    if args.paths.len() < 2 {
+        eyre::bail!("at least one source and one destination are required");
+    }
+    let dest_arg = args.paths.last().unwrap();
+    let source_args = &args.paths[..args.paths.len() - 1];
+
+    // Resolve destination path relative to vault root, adding .md if needed.
+    let mut dest_path = if dest_arg.is_absolute() {
+        dest_arg.clone()
+    } else {
+        let cwd = std::env::current_dir()?;
+        let candidate = cwd.join(dest_arg);
+        if candidate.exists() {
+            candidate
+        } else {
+            vault.path.join(dest_arg)
+        }
+    };
+    if dest_path.extension().and_then(|e| e.to_str()) != Some("md") {
+        dest_path.set_extension("md");
+    }
+
+    // Resolve and load sources.
+    let mut sources: Vec<Note> = Vec::new();
+    for src_arg in source_args {
+        let (note_path, _) = resolve_note_path(&vault, &src_arg.to_path_buf())?;
+        sources.push(Note::from_path(&note_path)?);
+    }
+
+    if args.dry_run {
+        let preview = vault.merge_preview(&sources, &dest_path)?;
+        match args.format {
+            OutputFormat::Plain => output::print_merge_preview_plain(&preview, &vault.path),
+            OutputFormat::Json => output::print_merge_preview_json(&preview, &vault.path),
+        }
+    } else {
+        let merged = vault.merge(&sources, &dest_path)?;
+        let rel = merged.path.strip_prefix(&vault.path).unwrap_or(&merged.path);
+        println!("{}", rel.display().to_string().cyan());
+    }
+    Ok(())
+}
 
 pub fn cmd_backlinks(vault: Vault, args: BacklinksArgs) -> eyre::Result<()> {
     let (note_path, _) = resolve_note_path(&vault, &args.note)?;

--- a/obsidian-cli/src/output.rs
+++ b/obsidian-cli/src/output.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use colored::Colorize;
-use obsidian_core::{Link, LocatedLink, LocatedTag, Note, RenamePreview};
+use obsidian_core::{Link, LocatedLink, LocatedTag, MergePreview, Note, RenamePreview};
 use serde::Serialize;
 
 pub fn print_search_plain(notes: &[Note], vault_path: &Path) {
@@ -105,6 +105,72 @@ pub fn print_rename_preview_json(preview: &RenamePreview, vault_path: &Path) {
     let out = RenamePreviewJson {
         new_path: rel_new.display().to_string(),
         id_will_update: preview.id_will_update,
+        updated_notes,
+    };
+    println!("{}", serde_json::to_string(&out).unwrap());
+}
+
+pub fn print_merge_preview_plain(preview: &MergePreview, vault_path: &Path) {
+    let rel_dest = preview.dest_path.strip_prefix(vault_path).unwrap_or(&preview.dest_path);
+    let dest_str = rel_dest.display().to_string();
+    let new_label = if preview.dest_is_new { "  (new)" } else { "" };
+    println!("{}{}", dest_str.cyan().bold(), new_label.dimmed());
+    for src in &preview.sources {
+        let rel = src.strip_prefix(vault_path).unwrap_or(src);
+        println!(" {} {}", "delete:".yellow(), rel.display().to_string().cyan());
+    }
+    for (path, count) in &preview.updated_notes {
+        let rel = path.strip_prefix(vault_path).unwrap_or(path);
+        let link_word = if *count == 1 { "link" } else { "links" };
+        let count_str = format!("({} {})", count, link_word).dimmed();
+        println!(
+            " {} {} {}",
+            "update:".green(),
+            rel.display().to_string().cyan(),
+            count_str
+        );
+    }
+}
+
+#[derive(Serialize)]
+struct MergePreviewNoteJson {
+    path: String,
+    link_count: usize,
+}
+
+#[derive(Serialize)]
+struct MergePreviewJson {
+    dest_path: String,
+    dest_is_new: bool,
+    sources: Vec<String>,
+    updated_notes: Vec<MergePreviewNoteJson>,
+}
+
+pub fn print_merge_preview_json(preview: &MergePreview, vault_path: &Path) {
+    let rel_dest = preview.dest_path.strip_prefix(vault_path).unwrap_or(&preview.dest_path);
+    let sources = preview
+        .sources
+        .iter()
+        .map(|s| {
+            let rel = s.strip_prefix(vault_path).unwrap_or(s);
+            rel.display().to_string()
+        })
+        .collect();
+    let updated_notes = preview
+        .updated_notes
+        .iter()
+        .map(|(path, count)| {
+            let rel = path.strip_prefix(vault_path).unwrap_or(path);
+            MergePreviewNoteJson {
+                path: rel.display().to_string(),
+                link_count: *count,
+            }
+        })
+        .collect();
+    let out = MergePreviewJson {
+        dest_path: rel_dest.display().to_string(),
+        dest_is_new: preview.dest_is_new,
+        sources,
         updated_notes,
     };
     println!("{}", serde_json::to_string(&out).unwrap());

--- a/obsidian-cli/tests/cli.rs
+++ b/obsidian-cli/tests/cli.rs
@@ -1140,6 +1140,321 @@ fn note_update_stdin_fail_fast_on_bad_path() {
         .stderr(predicate::str::contains("note not found"));
 }
 
+// --- merge tests ---
+
+#[test]
+fn merge_basic() {
+    let vault = make_vault();
+    write_note(vault.path(), "a.md", "Content A.");
+    write_note(vault.path(), "b.md", "Content B.");
+    let a = vault.path().join("a.md");
+    let b = vault.path().join("b.md");
+    let dest = vault.path().join("combined.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            a.to_str().unwrap(),
+            b.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("combined.md"));
+    assert!(dest.exists());
+    assert!(!a.exists());
+    assert!(!b.exists());
+    let content = fs::read_to_string(&dest).unwrap();
+    assert!(content.contains("Content A."));
+    assert!(content.contains("Content B."));
+}
+
+#[test]
+fn merge_into_existing() {
+    let vault = make_vault();
+    write_note(vault.path(), "src.md", "Source content.");
+    write_note(vault.path(), "dest.md", "Existing content.");
+    let src = vault.path().join("src.md");
+    let dest = vault.path().join("dest.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            src.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(!src.exists());
+    assert!(dest.exists());
+    let content = fs::read_to_string(&dest).unwrap();
+    assert!(content.contains("Existing content."));
+    assert!(content.contains("Source content."));
+}
+
+#[test]
+fn merge_updates_backlinks() {
+    let vault = make_vault();
+    write_note(vault.path(), "src.md", "Source.");
+    write_note(vault.path(), "other.md", "See [[src]] and [link](src.md).");
+    let src = vault.path().join("src.md");
+    let dest = vault.path().join("dest.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            src.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let other = fs::read_to_string(vault.path().join("other.md")).unwrap();
+    assert!(other.contains("[[dest]]"));
+    assert!(other.contains("dest.md"));
+    assert!(!other.contains("[[src]]"));
+}
+
+#[test]
+fn merge_multiple_sources() {
+    let vault = make_vault();
+    write_note(vault.path(), "a.md", "Body A.");
+    write_note(vault.path(), "b.md", "Body B.");
+    write_note(vault.path(), "c.md", "Body C.");
+    let a = vault.path().join("a.md");
+    let b = vault.path().join("b.md");
+    let c = vault.path().join("c.md");
+    let dest = vault.path().join("combined.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            a.to_str().unwrap(),
+            b.to_str().unwrap(),
+            c.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(!a.exists());
+    assert!(!b.exists());
+    assert!(!c.exists());
+    assert!(dest.exists());
+    let content = fs::read_to_string(&dest).unwrap();
+    assert!(content.contains("Body A."));
+    assert!(content.contains("Body B."));
+    assert!(content.contains("Body C."));
+}
+
+#[test]
+fn merge_tags_unioned() {
+    let vault = make_vault();
+    write_note(vault.path(), "a.md", "---\ntags: [rust]\n---\nBody A.");
+    write_note(vault.path(), "b.md", "---\ntags: [obsidian]\n---\nBody B.");
+    let a = vault.path().join("a.md");
+    let b = vault.path().join("b.md");
+    let dest = vault.path().join("combined.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            a.to_str().unwrap(),
+            b.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let content = fs::read_to_string(&dest).unwrap();
+    assert!(content.contains("rust"));
+    assert!(content.contains("obsidian"));
+}
+
+#[test]
+fn merge_dry_run_no_filesystem_changes() {
+    let vault = make_vault();
+    write_note(vault.path(), "a.md", "Content A.");
+    write_note(vault.path(), "b.md", "Content B.");
+    let a = vault.path().join("a.md");
+    let b = vault.path().join("b.md");
+    let dest = vault.path().join("combined.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            "--dry-run",
+            a.to_str().unwrap(),
+            b.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("combined.md"));
+    assert!(a.exists());
+    assert!(b.exists());
+    assert!(!dest.exists());
+}
+
+#[test]
+fn merge_dry_run_shows_sources_and_dest() {
+    let vault = make_vault();
+    write_note(vault.path(), "a.md", "Content A.");
+    write_note(vault.path(), "b.md", "Content B.");
+    let a = vault.path().join("a.md");
+    let b = vault.path().join("b.md");
+    let dest = vault.path().join("combined.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            "--dry-run",
+            a.to_str().unwrap(),
+            b.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("a.md"))
+        .stdout(predicate::str::contains("b.md"))
+        .stdout(predicate::str::contains("(new)"));
+}
+
+#[test]
+fn merge_dry_run_json_format() {
+    let vault = make_vault();
+    write_note(vault.path(), "a.md", "Content A.");
+    write_note(vault.path(), "b.md", "Content B.");
+    write_note(vault.path(), "other.md", "See [[a]].");
+    let a = vault.path().join("a.md");
+    let b = vault.path().join("b.md");
+    let dest = vault.path().join("combined.md");
+    let output = obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            "--dry-run",
+            "--format",
+            "json",
+            a.to_str().unwrap(),
+            b.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let s = String::from_utf8(output).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&s).unwrap();
+    assert!(v["dest_path"].as_str().unwrap().contains("combined.md"));
+    assert_eq!(v["dest_is_new"].as_bool().unwrap(), true);
+    assert!(v["sources"].as_array().unwrap().len() == 2);
+    let updated = v["updated_notes"].as_array().unwrap();
+    assert_eq!(updated.len(), 1);
+    assert!(updated[0]["path"].as_str().unwrap().contains("other.md"));
+    assert_eq!(updated[0]["link_count"].as_u64().unwrap(), 1);
+}
+
+#[test]
+fn merge_source_is_dest_errors() {
+    let vault = make_vault();
+    write_note(vault.path(), "note.md", "Content.");
+    write_note(vault.path(), "other.md", "Content.");
+    let note = vault.path().join("note.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            note.to_str().unwrap(),
+            note.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("same as destination"));
+}
+
+#[test]
+fn merge_dest_dir_missing_errors() {
+    let vault = make_vault();
+    write_note(vault.path(), "src.md", "Content.");
+    let src = vault.path().join("src.md");
+    let dest = vault.path().join("nonexistent/dest.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            src.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("directory not found"));
+}
+
+#[test]
+fn merge_adds_md_extension_if_missing() {
+    let vault = make_vault();
+    write_note(vault.path(), "src.md", "Content.");
+    let src = vault.path().join("src.md");
+    let dest_no_ext = vault.path().join("combined");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            src.to_str().unwrap(),
+            dest_no_ext.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("combined.md"));
+    assert!(vault.path().join("combined.md").exists());
+}
+
+#[test]
+fn merge_dry_run_updated_notes_backlinks() {
+    let vault = make_vault();
+    write_note(vault.path(), "src.md", "Source.");
+    write_note(vault.path(), "linker.md", "See [[src]].");
+    let src = vault.path().join("src.md");
+    let dest = vault.path().join("dest.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "merge",
+            "--dry-run",
+            src.to_str().unwrap(),
+            dest.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("linker.md"));
+    // Dry run: no changes
+    let linker = fs::read_to_string(vault.path().join("linker.md")).unwrap();
+    assert_eq!(linker, "See [[src]].");
+}
+
 #[test]
 fn color_and_no_color_are_mutually_exclusive() {
     let vault = make_vault();

--- a/obsidian-core/src/error.rs
+++ b/obsidian-core/src/error.rs
@@ -8,6 +8,8 @@ pub enum VaultError {
     NoteAlreadyExists(PathBuf),
     #[error("directory not found: {0}")]
     DirectoryNotFound(PathBuf),
+    #[error("source note is the same as destination: {0}")]
+    MergeSourceIsDestination(PathBuf),
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error(transparent)]

--- a/obsidian-core/src/lib.rs
+++ b/obsidian-core/src/lib.rs
@@ -9,4 +9,4 @@ pub use link::{Link, LocatedLink, Location};
 pub use note::Note;
 pub use search::SearchQuery;
 pub use tag::LocatedTag;
-pub use vault::{RenamePreview, Vault};
+pub use vault::{MergePreview, RenamePreview, Vault};

--- a/obsidian-core/src/vault.rs
+++ b/obsidian-core/src/vault.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use gray_matter::Pod;
+use indexmap::IndexMap;
 
 use crate::{Link, LocatedLink, Note, NoteError, VaultError, search};
 use rayon::prelude::*;
@@ -102,6 +103,26 @@ pub struct RenamePreview {
     pub id_will_update: bool,
     /// Notes with backlinks that would be rewritten, sorted by path. Each entry is (path, link_count).
     pub updated_notes: Vec<(PathBuf, usize)>,
+}
+
+/// Public summary of what a merge would change, without touching the filesystem.
+pub struct MergePreview {
+    pub dest_path: PathBuf,
+    pub dest_is_new: bool,
+    /// Source paths that would be deleted.
+    pub sources: Vec<PathBuf>,
+    /// Notes with backlinks to any source that would be rewritten, sorted by path. Each entry is (path, link_count).
+    pub updated_notes: Vec<(PathBuf, usize)>,
+}
+
+struct MergeOp {
+    dest_is_new: bool,
+    /// Combined body content for the destination note (no leading whitespace).
+    merged_content: String,
+    /// Merged frontmatter for the destination note.
+    merged_frontmatter: Option<IndexMap<String, Pod>>,
+    /// External notes (not sources, not dest) with backlinks to rewrite.
+    per_note_replacements: Vec<(PathBuf, Vec<(LocatedLink, String)>)>,
 }
 
 impl Vault {
@@ -326,6 +347,249 @@ impl Vault {
         Ok(RenamePreview {
             new_path: new_path.to_path_buf(),
             id_will_update: op.frontmatter_id_will_update,
+            updated_notes,
+        })
+    }
+
+    /// Computes all changes required to merge `sources` into `dest_path` without performing I/O.
+    fn compute_merge_op(&self, sources: &[Note], dest_path: &Path) -> Result<MergeOp, VaultError> {
+        use std::collections::HashMap;
+
+        let dest_dir = dest_path.parent().unwrap_or_else(|| Path::new("."));
+        if !dest_dir.is_dir() {
+            return Err(VaultError::DirectoryNotFound(dest_dir.to_path_buf()));
+        }
+
+        for source in sources {
+            if source.path == dest_path {
+                return Err(VaultError::MergeSourceIsDestination(source.path.clone()));
+            }
+        }
+
+        let dest_is_new = !dest_path.exists();
+
+        let dest_stem = dest_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default()
+            .to_string();
+
+        let source_paths: Vec<&Path> = sources.iter().map(|s| s.path.as_path()).collect();
+
+        // Aggregate backlink replacements per linking note, skipping sources and dest.
+        let mut replacements_by_path: HashMap<PathBuf, Vec<(LocatedLink, String)>> = HashMap::new();
+
+        for source in sources {
+            let backlinks = self.backlinks(source);
+            for (linking_note, links) in backlinks {
+                if source_paths.iter().any(|p| *p == linking_note.path) {
+                    continue;
+                }
+                if linking_note.path == dest_path {
+                    continue;
+                }
+
+                let entry = replacements_by_path.entry(linking_note.path.clone()).or_default();
+
+                for ll in links {
+                    let new_text = match &ll.link {
+                        Link::Wiki { heading, alias, .. } => {
+                            let mut wiki = format!("[[{}", dest_stem);
+                            if let Some(h) = heading {
+                                wiki.push('#');
+                                wiki.push_str(h);
+                            }
+                            if let Some(a) = alias {
+                                wiki.push('|');
+                                wiki.push_str(a);
+                            }
+                            wiki.push_str("]]");
+                            Some(wiki)
+                        }
+                        Link::Markdown { text, url } => {
+                            let fragment = url.find('#').map(|i| url[i..].to_string());
+                            let new_url = relative_path(self.path.as_path(), dest_path);
+                            let new_url_str = new_url.to_string_lossy().replace('\\', "/");
+                            let full_url = match fragment {
+                                Some(f) => format!("{}{}", new_url_str, f),
+                                None => new_url_str.to_string(),
+                            };
+                            Some(format!("[{}]({})", text, full_url))
+                        }
+                        _ => None,
+                    };
+                    if let Some(text) = new_text {
+                        entry.push((ll, text));
+                    }
+                }
+            }
+        }
+
+        let per_note_replacements: Vec<(PathBuf, Vec<(LocatedLink, String)>)> = replacements_by_path
+            .into_iter()
+            .filter(|(_, r)| !r.is_empty())
+            .collect();
+
+        // Load existing destination if present.
+        let (dest_body, dest_fm_tags, dest_fm_aliases, dest_frontmatter) = if dest_is_new {
+            (String::new(), Vec::<String>::new(), Vec::<String>::new(), None)
+        } else {
+            let d = Note::from_path(dest_path)?;
+            let tags = d
+                .frontmatter
+                .as_ref()
+                .and_then(|fm| fm.get("tags"))
+                .and_then(|p| p.as_vec().ok())
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|p| p.as_string().ok())
+                .collect::<Vec<_>>();
+            let aliases = d
+                .frontmatter
+                .as_ref()
+                .and_then(|fm| fm.get("aliases"))
+                .and_then(|p| p.as_vec().ok())
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|p| p.as_string().ok())
+                .collect::<Vec<_>>();
+            let body = d.content.trim_start().to_string();
+            let fm = d.frontmatter;
+            (body, tags, aliases, fm)
+        };
+
+        // Build merged body.
+        let mut body_parts: Vec<String> = Vec::new();
+        if !dest_body.is_empty() {
+            body_parts.push(dest_body);
+        }
+        for source in sources {
+            let body = source.content.trim_start().to_string();
+            if !body.is_empty() {
+                body_parts.push(body);
+            }
+        }
+        let merged_content = body_parts.join("\n\n---\n\n");
+
+        // Build merged frontmatter: dest wins on id/title, union on tags/aliases.
+        let mut fm: IndexMap<String, Pod> = dest_frontmatter.unwrap_or_default();
+
+        let mut tag_strings: Vec<String> = dest_fm_tags;
+        for source in sources {
+            for tag in &source.tags {
+                if !tag_strings.contains(tag) {
+                    tag_strings.push(tag.clone());
+                }
+            }
+        }
+        if !tag_strings.is_empty() {
+            fm.insert(
+                "tags".to_string(),
+                Pod::Array(tag_strings.into_iter().map(Pod::String).collect()),
+            );
+        }
+
+        let mut alias_strings: Vec<String> = dest_fm_aliases;
+        for source in sources {
+            let src_aliases: Vec<String> = source
+                .frontmatter
+                .as_ref()
+                .and_then(|sfm| sfm.get("aliases"))
+                .and_then(|p| p.as_vec().ok())
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|p| p.as_string().ok())
+                .collect();
+            for alias in src_aliases {
+                if !alias_strings.contains(&alias) {
+                    alias_strings.push(alias);
+                }
+            }
+        }
+        if !alias_strings.is_empty() {
+            fm.insert(
+                "aliases".to_string(),
+                Pod::Array(alias_strings.into_iter().map(Pod::String).collect()),
+            );
+        }
+
+        let merged_frontmatter = if fm.is_empty() { None } else { Some(fm) };
+
+        Ok(MergeOp {
+            dest_is_new,
+            merged_content,
+            merged_frontmatter,
+            per_note_replacements,
+        })
+    }
+
+    /// Merges `sources` into `dest_path`: appends each source's body to the destination,
+    /// union-merges tags and aliases, rewrites all backlinks to sources in other notes to
+    /// point to the destination, and deletes the source files.
+    ///
+    /// The destination is created if it doesn't exist, or its content is appended to if it does.
+    /// Returns the resulting destination [`Note`].
+    pub fn merge(&self, sources: &[Note], dest_path: &Path) -> Result<Note, VaultError> {
+        let op = self.compute_merge_op(sources, dest_path)?;
+
+        // Build and write destination note.
+        if op.dest_is_new {
+            let dest = Note {
+                path: dest_path.to_path_buf(),
+                id: dest_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                title: None,
+                aliases: Vec::new(),
+                tags: Vec::new(),
+                content: op.merged_content,
+                frontmatter: op.merged_frontmatter,
+                frontmatter_line_count: 0,
+            };
+            dest.write()?;
+        } else {
+            let mut dest = Note::from_path(dest_path)?;
+            dest.content = op.merged_content;
+            dest.frontmatter = op.merged_frontmatter;
+            dest.write()?;
+        }
+
+        let dest_note = Note::from_path(dest_path)?;
+
+        // Rewrite backlinks in external notes.
+        for (note_path, replacements) in op.per_note_replacements {
+            let raw_content = std::fs::read_to_string(&note_path)?;
+            let new_content = rewrite_links(&raw_content, replacements);
+            std::fs::write(&note_path, new_content)?;
+        }
+
+        // Delete source files.
+        for source in sources {
+            std::fs::remove_file(&source.path)?;
+        }
+
+        Ok(dest_note)
+    }
+
+    /// Returns a preview of what [`merge`](Self::merge) would change without touching the filesystem.
+    ///
+    /// Same validation and error variants as `merge`.
+    pub fn merge_preview(&self, sources: &[Note], dest_path: &Path) -> Result<MergePreview, VaultError> {
+        let op = self.compute_merge_op(sources, dest_path)?;
+
+        let mut updated_notes: Vec<(PathBuf, usize)> = op
+            .per_note_replacements
+            .iter()
+            .map(|(path, reps)| (path.clone(), reps.len()))
+            .collect();
+        updated_notes.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        Ok(MergePreview {
+            dest_path: dest_path.to_path_buf(),
+            dest_is_new: op.dest_is_new,
+            sources: sources.iter().map(|s| s.path.clone()).collect(),
             updated_notes,
         })
     }

--- a/obsidian-core/src/vault.rs
+++ b/obsidian-core/src/vault.rs
@@ -513,6 +513,19 @@ impl Vault {
             );
         }
 
+        // Union remaining source frontmatter fields (dest wins on conflicts; id/tags/aliases are
+        // excluded because they're handled above or must not be inherited from sources).
+        const SKIP_KEYS: &[&str] = &["id", "tags", "aliases"];
+        for source in sources {
+            if let Some(sfm) = &source.frontmatter {
+                for (k, v) in sfm {
+                    if !SKIP_KEYS.contains(&k.as_str()) {
+                        fm.entry(k.clone()).or_insert_with(|| v.clone());
+                    }
+                }
+            }
+        }
+
         let merged_frontmatter = if fm.is_empty() { None } else { Some(fm) };
 
         Ok(MergeOp {
@@ -1242,5 +1255,160 @@ mod tests {
 
         let source_content = fs::read_to_string(dir.path().join("source.md")).unwrap();
         assert_eq!(source_content, "See [[new-stem#h1|display]].");
+    }
+
+    // --- merge tests ---
+
+    #[test]
+    fn merge_basic_creates_dest_and_deletes_sources() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("a.md"), "Body A.").unwrap();
+        fs::write(dir.path().join("b.md"), "Body B.").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let a = Note::from_path(dir.path().join("a.md")).unwrap();
+        let b = Note::from_path(dir.path().join("b.md")).unwrap();
+        let dest_path = dir.path().join("combined.md");
+        vault.merge(&[a, b], &dest_path).unwrap();
+
+        assert!(!dir.path().join("a.md").exists());
+        assert!(!dir.path().join("b.md").exists());
+        assert!(dest_path.exists());
+        let content = fs::read_to_string(&dest_path).unwrap();
+        assert!(content.contains("Body A."));
+        assert!(content.contains("Body B."));
+    }
+
+    #[test]
+    fn merge_into_existing_appends_content() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("src.md"), "Source body.").unwrap();
+        fs::write(dir.path().join("dest.md"), "Existing body.").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let src = Note::from_path(dir.path().join("src.md")).unwrap();
+        vault.merge(&[src], &dir.path().join("dest.md")).unwrap();
+
+        assert!(!dir.path().join("src.md").exists());
+        let content = fs::read_to_string(dir.path().join("dest.md")).unwrap();
+        assert!(content.contains("Existing body."));
+        assert!(content.contains("Source body."));
+    }
+
+    #[test]
+    fn merge_unions_tags() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("a.md"), "---\ntags: [rust]\n---\nBody A.").unwrap();
+        fs::write(dir.path().join("b.md"), "---\ntags: [obsidian]\n---\nBody B.").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let a = Note::from_path(dir.path().join("a.md")).unwrap();
+        let b = Note::from_path(dir.path().join("b.md")).unwrap();
+        let dest_path = dir.path().join("combined.md");
+        vault.merge(&[a, b], &dest_path).unwrap();
+
+        let combined = Note::from_path(&dest_path).unwrap();
+        assert!(combined.tags.contains(&"rust".to_string()));
+        assert!(combined.tags.contains(&"obsidian".to_string()));
+    }
+
+    #[test]
+    fn merge_does_not_inherit_source_id() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("src.md"),
+            "---\nid: source-id\nauthor: alice\n---\nBody.",
+        )
+        .unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let src = Note::from_path(dir.path().join("src.md")).unwrap();
+        let dest_path = dir.path().join("dest.md");
+        vault.merge(&[src], &dest_path).unwrap();
+
+        let dest = Note::from_path(&dest_path).unwrap();
+        // id must NOT come from source
+        assert_ne!(dest.id, "source-id");
+        // other fields ARE inherited when dest is new
+        let fm = dest.frontmatter.unwrap();
+        assert!(fm.contains_key("author"));
+        assert!(!fm.contains_key("id"));
+    }
+
+    #[test]
+    fn merge_other_frontmatter_fields_inherited_from_source_when_dest_is_new() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("src.md"),
+            "---\nauthor: alice\ncreated: 2024-01-01\n---\nBody.",
+        )
+        .unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let src = Note::from_path(dir.path().join("src.md")).unwrap();
+        let dest_path = dir.path().join("dest.md");
+        vault.merge(&[src], &dest_path).unwrap();
+
+        let dest = Note::from_path(&dest_path).unwrap();
+        let fm = dest.frontmatter.unwrap();
+        assert!(fm.contains_key("author"));
+        assert!(fm.contains_key("created"));
+    }
+
+    #[test]
+    fn merge_dest_wins_on_conflicting_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("src.md"), "---\nauthor: alice\n---\nSource.").unwrap();
+        fs::write(dir.path().join("dest.md"), "---\nauthor: bob\n---\nDest.").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let src = Note::from_path(dir.path().join("src.md")).unwrap();
+        vault.merge(&[src], &dir.path().join("dest.md")).unwrap();
+
+        let dest = Note::from_path(dir.path().join("dest.md")).unwrap();
+        let fm = dest.frontmatter.unwrap();
+        assert_eq!(fm["author"].as_string().unwrap(), "bob");
+    }
+
+    #[test]
+    fn merge_updates_wiki_backlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("src.md"), "Source.").unwrap();
+        fs::write(dir.path().join("linker.md"), "See [[src]].").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let src = Note::from_path(dir.path().join("src.md")).unwrap();
+        vault.merge(&[src], &dir.path().join("dest.md")).unwrap();
+
+        let linker = fs::read_to_string(dir.path().join("linker.md")).unwrap();
+        assert_eq!(linker, "See [[dest]].");
+    }
+
+    #[test]
+    fn merge_source_is_dest_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("note.md"), "Content.").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let note = Note::from_path(dir.path().join("note.md")).unwrap();
+        let result = vault.merge(&[note], &dir.path().join("note.md"));
+
+        assert!(matches!(result, Err(VaultError::MergeSourceIsDestination(_))));
+    }
+
+    #[test]
+    fn merge_preview_does_not_modify_filesystem() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("src.md"), "Source.").unwrap();
+        fs::write(dir.path().join("linker.md"), "See [[src]].").unwrap();
+
+        let vault = Vault::open(dir.path()).unwrap();
+        let src = Note::from_path(dir.path().join("src.md")).unwrap();
+        vault.merge_preview(&[src], &dir.path().join("dest.md")).unwrap();
+
+        assert!(dir.path().join("src.md").exists());
+        assert!(!dir.path().join("dest.md").exists());
+        let linker = fs::read_to_string(dir.path().join("linker.md")).unwrap();
+        assert_eq!(linker, "See [[src]].");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `obsidian note merge <src1> [<src2>...] <destination>` subcommand to `obsidian note`
- Source bodies are appended to destination with `---` separators; frontmatter tags and aliases are union-merged; source files are deleted
- All backlinks to any source in the vault are rewritten to point to the destination
- `--dry-run` flag (with `--format plain|json`) previews changes without touching the filesystem

## Test Plan

- [ ] `cargo test` passes (206 tests: 66 CLI integration + 140 unit)
- [ ] `merge_basic`: two sources into new dest → content combined, sources deleted
- [ ] `merge_into_existing`: appends to existing dest, deletes source
- [ ] `merge_updates_backlinks`: wiki and markdown backlinks rewritten to dest
- [ ] `merge_multiple_sources`: 3+ sources handled correctly
- [ ] `merge_tags_unioned`: source tags appear in merged frontmatter
- [ ] `merge_dry_run_*`: no filesystem changes, output shows what would happen
- [ ] `merge_dry_run_json_format`: valid JSON with correct fields
- [ ] `merge_source_is_dest_errors` / `merge_dest_dir_missing_errors`: error cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)