### PR TITLE
Add --add-tag, --rm-tag, and --add-alias to note update

### DIFF
--- a/obsidian-cli/src/args.rs
+++ b/obsidian-cli/src/args.rs
@@ -139,7 +139,13 @@ pub struct UpdateArgs {
     pub note: Option<PathBuf>,
     /// Add tag(s) to frontmatter (repeatable)
     #[arg(long, short = 't')]
-    pub tag: Vec<String>,
+    pub add_tag: Vec<String>,
+    /// Remove tag(s) from frontmatter (repeatable)
+    #[arg(long)]
+    pub rm_tag: Vec<String>,
+    /// Add alias(es) to frontmatter (repeatable)
+    #[arg(long, short = 'a')]
+    pub add_alias: Vec<String>,
     /// Output format
     #[arg(long, short = 'f', default_value = "plain")]
     pub format: OutputFormat,

--- a/obsidian-cli/src/note.rs
+++ b/obsidian-cli/src/note.rs
@@ -94,7 +94,7 @@ pub fn cmd_rename(vault: Vault, args: RenameArgs) -> eyre::Result<()> {
 
 pub fn cmd_note_update(vault: Vault, args: UpdateArgs) -> eyre::Result<()> {
     if let Some(note_path) = args.note {
-        let note = update_single_note(&vault, &note_path, &args.tag)?;
+        let note = update_single_note(&vault, &note_path, &args.add_tag, &args.rm_tag, &args.add_alias)?;
         match args.format {
             OutputFormat::Plain => output::print_note_update_plain(&note, &vault.path),
             OutputFormat::Json => output::print_note_update_json(&note, &vault.path),
@@ -114,7 +114,13 @@ pub fn cmd_note_update(vault: Vault, args: UpdateArgs) -> eyre::Result<()> {
         if line.is_empty() {
             continue;
         }
-        let note = update_single_note(&vault, std::path::Path::new(&line), &args.tag)?;
+        let note = update_single_note(
+            &vault,
+            std::path::Path::new(&line),
+            &args.add_tag,
+            &args.rm_tag,
+            &args.add_alias,
+        )?;
         notes.push(note);
     }
 
@@ -129,11 +135,20 @@ pub fn cmd_note_update(vault: Vault, args: UpdateArgs) -> eyre::Result<()> {
     Ok(())
 }
 
-fn update_single_note(vault: &Vault, note_arg: &std::path::Path, tags: &[String]) -> eyre::Result<Note> {
+fn update_single_note(
+    vault: &Vault,
+    note_arg: &std::path::Path,
+    add_tags: &[String],
+    rm_tags: &[String],
+    add_aliases: &[String],
+) -> eyre::Result<Note> {
     let (note_path, _) = resolve_note_path(vault, &note_arg.to_path_buf())?;
     let mut note = Note::from_path(&note_path)?;
 
-    let new_tags: Vec<String> = tags.iter().filter(|t| !note.tags.contains(*t)).cloned().collect();
+    let mut dirty = false;
+
+    // Add tags
+    let new_tags: Vec<String> = add_tags.iter().filter(|t| !note.tags.contains(*t)).cloned().collect();
     if !new_tags.is_empty() {
         let fm = note.frontmatter.get_or_insert_with(indexmap::IndexMap::new);
         let tags_entry = fm
@@ -145,6 +160,41 @@ fn update_single_note(vault: &Vault, note_arg: &std::path::Path, tags: &[String]
             }
         }
         note.tags.extend(new_tags);
+        dirty = true;
+    }
+
+    // Remove tags
+    if !rm_tags.is_empty() {
+        if let Some(fm) = note.frontmatter.as_mut()
+            && let Some(gray_matter::Pod::Array(arr)) = fm.get_mut("tags")
+        {
+            arr.retain(|p| p.as_string().map(|s| !rm_tags.contains(&s)).unwrap_or(true));
+        }
+        note.tags.retain(|t| !rm_tags.contains(t));
+        dirty = true;
+    }
+
+    // Add aliases
+    let new_aliases: Vec<String> = add_aliases
+        .iter()
+        .filter(|a| !note.aliases.contains(*a))
+        .cloned()
+        .collect();
+    if !new_aliases.is_empty() {
+        let fm = note.frontmatter.get_or_insert_with(indexmap::IndexMap::new);
+        let aliases_entry = fm
+            .entry("aliases".to_string())
+            .or_insert_with(|| gray_matter::Pod::Array(Vec::new()));
+        if let gray_matter::Pod::Array(arr) = aliases_entry {
+            for alias in &new_aliases {
+                arr.push(gray_matter::Pod::String(alias.clone()));
+            }
+        }
+        note.aliases.extend(new_aliases);
+        dirty = true;
+    }
+
+    if dirty {
         note.write_frontmatter()?;
     }
 

--- a/obsidian-cli/tests/cli.rs
+++ b/obsidian-cli/tests/cli.rs
@@ -877,7 +877,7 @@ fn note_update_adds_tag_to_existing_frontmatter_tags() {
             vault.path().to_str().unwrap(),
             "note",
             "update",
-            "--tag",
+            "--add-tag",
             "obsidian",
             note_path.to_str().unwrap(),
         ])
@@ -900,7 +900,7 @@ fn note_update_creates_tags_field_when_frontmatter_has_none() {
             vault.path().to_str().unwrap(),
             "note",
             "update",
-            "--tag",
+            "--add-tag",
             "newtag",
             note_path.to_str().unwrap(),
         ])
@@ -921,7 +921,7 @@ fn note_update_creates_frontmatter_when_note_has_none() {
             vault.path().to_str().unwrap(),
             "note",
             "update",
-            "--tag",
+            "--add-tag",
             "newtag",
             note_path.to_str().unwrap(),
         ])
@@ -943,7 +943,7 @@ fn note_update_idempotent_does_not_duplicate_existing_tag() {
             vault.path().to_str().unwrap(),
             "note",
             "update",
-            "--tag",
+            "--add-tag",
             "rust",
             note_path.to_str().unwrap(),
         ])
@@ -964,9 +964,9 @@ fn note_update_multiple_tags() {
             vault.path().to_str().unwrap(),
             "note",
             "update",
-            "--tag",
+            "--add-tag",
             "alpha",
-            "--tag",
+            "--add-tag",
             "beta",
             note_path.to_str().unwrap(),
         ])
@@ -989,7 +989,7 @@ fn note_update_json_format() {
             vault.path().to_str().unwrap(),
             "note",
             "update",
-            "--tag",
+            "--add-tag",
             "obsidian",
             "--format",
             "json",
@@ -1009,6 +1009,137 @@ fn note_update_json_format() {
     assert!(tag_strs.contains(&"obsidian"));
 }
 
+#[test]
+fn note_update_rm_tag_removes_existing_tag() {
+    let vault = make_vault();
+    write_note(vault.path(), "note.md", "---\ntags: [rust, obsidian]\n---\nContent.");
+    let note_path = vault.path().join("note.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "update",
+            "--rm-tag",
+            "obsidian",
+            note_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let content = fs::read_to_string(&note_path).unwrap();
+    assert!(content.contains("rust"));
+    assert!(!content.contains("obsidian"));
+}
+
+#[test]
+fn note_update_rm_tag_no_op_when_tag_absent() {
+    let vault = make_vault();
+    write_note(vault.path(), "note.md", "---\ntags: [rust]\n---\nContent.");
+    let note_path = vault.path().join("note.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "update",
+            "--rm-tag",
+            "nonexistent",
+            note_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let content = fs::read_to_string(&note_path).unwrap();
+    assert!(content.contains("rust"));
+}
+
+#[test]
+fn note_update_add_and_rm_tag_together() {
+    let vault = make_vault();
+    write_note(vault.path(), "note.md", "---\ntags: [rust]\n---\nContent.");
+    let note_path = vault.path().join("note.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "update",
+            "--add-tag",
+            "obsidian",
+            "--rm-tag",
+            "rust",
+            note_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let content = fs::read_to_string(&note_path).unwrap();
+    assert!(content.contains("obsidian"));
+    assert!(!content.contains("rust"));
+}
+
+#[test]
+fn note_update_add_alias_adds_to_frontmatter() {
+    let vault = make_vault();
+    write_note(vault.path(), "note.md", "---\ntitle: My Note\n---\nContent.");
+    let note_path = vault.path().join("note.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "update",
+            "--add-alias",
+            "my-alias",
+            note_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let content = fs::read_to_string(&note_path).unwrap();
+    assert!(content.contains("my-alias"));
+}
+
+#[test]
+fn note_update_add_alias_creates_frontmatter_when_absent() {
+    let vault = make_vault();
+    write_note(vault.path(), "note.md", "Plain content.");
+    let note_path = vault.path().join("note.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "update",
+            "--add-alias",
+            "my-alias",
+            note_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let content = fs::read_to_string(&note_path).unwrap();
+    assert!(content.contains("my-alias"));
+    assert!(content.contains("---"));
+}
+
+#[test]
+fn note_update_add_alias_idempotent() {
+    let vault = make_vault();
+    write_note(vault.path(), "note.md", "---\naliases: [my-alias]\n---\nContent.");
+    let note_path = vault.path().join("note.md");
+    obsidian()
+        .args([
+            "--vault",
+            vault.path().to_str().unwrap(),
+            "note",
+            "update",
+            "--add-alias",
+            "my-alias",
+            note_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let content = fs::read_to_string(&note_path).unwrap();
+    assert_eq!(content.matches("my-alias").count(), 1);
+}
+
 // --- note update stdin tests ---
 
 #[test]
@@ -1025,7 +1156,7 @@ fn note_update_stdin_adds_tag_to_multiple_notes() {
             vault.path().to_str().unwrap(),
             "note",
             "update",
-            "--tag",
+            "--add-tag",
             "obsidian",
         ])
         .write_stdin(stdin_input)
@@ -1053,7 +1184,7 @@ fn note_update_stdin_json_format_returns_array() {
             vault.path().to_str().unwrap(),
             "note",
             "update",
-            "--tag",
+            "--add-tag",
             "obsidian",
             "--format",
             "json",
@@ -1090,7 +1221,7 @@ fn note_update_stdin_skips_empty_lines() {
             vault.path().to_str().unwrap(),
             "note",
             "update",
-            "--tag",
+            "--add-tag",
             "newtag",
         ])
         .write_stdin(stdin_input)
@@ -1110,7 +1241,7 @@ fn note_update_stdin_empty_input_succeeds_with_no_output() {
             vault.path().to_str().unwrap(),
             "note",
             "update",
-            "--tag",
+            "--add-tag",
             "newtag",
         ])
         .write_stdin("")
@@ -1131,7 +1262,7 @@ fn note_update_stdin_fail_fast_on_bad_path() {
             vault.path().to_str().unwrap(),
             "note",
             "update",
-            "--tag",
+            "--add-tag",
             "newtag",
         ])
         .write_stdin(stdin_input)


### PR DESCRIPTION
## Summary

- Renames `--tag` to `--add-tag` (short `-t` preserved) for consistency with the new options
- Adds `--rm-tag` to remove tags from frontmatter
- Adds `--add-alias` (short `-a`) to add aliases to frontmatter
- All three options are repeatable
- File is only written when at least one change is made

## Test plan

- [x] Updated all existing `--tag` references in tests to `--add-tag`
- [x] Added tests for `--rm-tag`: removes existing tag, no-op when absent, combined with `--add-tag`
- [x] Added tests for `--add-alias`: adds to frontmatter, creates frontmatter when absent, idempotent

🤖 Generated with [Claude Code](https://claude.com/claude-code)