### PR TITLE
Implement some basic LSP functionality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This file provides guidance to coding agents when working in this repository.
 - `obsidian-core` (crate name: `obsidian-rs-core`; library name: `obsidian_core`): core API used by the other sub-crates.
 - `obsidian-cli` (crate name: `obsidian-rs-cli`; binary name: `obsidian`): command-line interface exposing `search`, `note`, `tags`, and `check` commands. The `note` subcommand supports `backlinks`, `merge`, `patch`, `rename`, and `update`.
 - `obsidian-mcp` (crate name: `obsidian-rs-mcp`; binary name: `obsidian-mcp`): MCP (Model Context Protocol) server over STDIO transport. Exposes vault operations as MCP tools: `read_note`, `write_note`, `patch_note`, `update_note`, `search_notes`, `rename_note`, `list_tags`, `search_tags`, `check_vault`. Vault path resolved in order: `--vault <PATH>` CLI arg, then `OBSIDIAN_VAULT` env var, then `open_from_cwd()`. Uses the `rmcp` crate with `tokio` for async handling of blocking vault I/O.
+- `obsidian-lsp` (crate name: `obsidian-rs-lsp`; binary name: `obsidian-lsp`): Language Server Protocol server over STDIO transport. Resolves the vault with the same precedence as `obsidian-mcp` and currently provides initialization, full-document sync for open buffers, in-memory note shadowing through `Vault::load_note()` / `unload_note()`, health diagnostics for broken links and duplicate IDs or aliases, and hover metadata for note links via `tower-lsp` and `tokio`.
 
 ## Workspace Structure
 
@@ -31,10 +32,17 @@ This file provides guidance to coding agents when working in this repository.
   - `src/server.rs` — `VaultServer` struct with `#[tool_router]` impl (9 tools) and `#[tool_handler]` `ServerHandler` impl
   - `src/tools.rs` — parameter structs (`Deserialize + JsonSchema`) for all 9 tools
   - `src/error.rs` — `vault_err`, `note_err`, `search_err`, `other_err` helpers converting core errors to `rmcp::ErrorData`
+- `obsidian-lsp/` — the LSP server binary crate
+  - `src/main.rs` — entry point: parses CLI args, initializes error reporting/logging, resolves the vault, and starts the STDIO LSP server
+  - `src/args.rs` — clap args and vault resolution helper for `--vault`, `OBSIDIAN_VAULT`, and `open_from_cwd()`
+  - `src/server.rs` — `Backend` implementation of `tower_lsp::LanguageServer` for initialize/open/change/close flows, diagnostics publication, and hover requests
+  - `src/state.rs` — shared backend state plus snapshot-based diagnostics and hover computation helpers
+  - `src/uri.rs` — file URI/path conversion helpers and vault-relative path validation
+  - `tests/lsp_integration.rs` — end-to-end stdio JSON-RPC harness covering initialize, diagnostics, hover, document sync notifications, shutdown, and exit
 
 ## Development
 
-- Always run `cargo fmt` after making changes to ensure consistent code formatting.
+- After making changes, always run `cargo fmt` to ensure consistent code formatting and `cargo clippy -- -D warnings` to check for linting issues.
 - Always update this file when new modules, crates, or features are added to the project.
 - Always update the @CHANGELOG.md and @README.md when adding new features, changing an API, or fixing bugs.
 
@@ -54,7 +62,7 @@ cargo test
 cargo test <test_name>
 
 # Lint
-cargo clippy
+cargo clippy -- -D warnings
 
 # Format
 cargo fmt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ This file provides guidance to coding agents when working in this repository.
 - `obsidian-core` (crate name: `obsidian-rs-core`; library name: `obsidian_core`): core API used by the other sub-crates.
 - `obsidian-cli` (crate name: `obsidian-rs-cli`; binary name: `obsidian`): command-line interface exposing `search`, `note`, `tags`, and `check` commands. The `note` subcommand supports `backlinks`, `merge`, `patch`, `rename`, and `update`.
 - `obsidian-mcp` (crate name: `obsidian-rs-mcp`; binary name: `obsidian-mcp`): MCP (Model Context Protocol) server over STDIO transport. Exposes vault operations as MCP tools: `read_note`, `write_note`, `patch_note`, `update_note`, `search_notes`, `rename_note`, `list_tags`, `search_tags`, `check_vault`. Vault path resolved in order: `--vault <PATH>` CLI arg, then `OBSIDIAN_VAULT` env var, then `open_from_cwd()`. Uses the `rmcp` crate with `tokio` for async handling of blocking vault I/O.
-- `obsidian-lsp` (crate name: `obsidian-rs-lsp`; binary name: `obsidian-lsp`): Language Server Protocol server over STDIO transport. Resolves the vault with the same precedence as `obsidian-mcp` and currently provides initialization, full-document sync for open buffers, in-memory note shadowing through `Vault::load_note()` / `unload_note()`, health diagnostics for broken links and duplicate IDs or aliases, and hover metadata for note links via `tower-lsp` and `tokio`.
+- `obsidian-lsp` (crate name: `obsidian-rs-lsp`; binary name: `obsidian-lsp`): Language Server Protocol server over STDIO transport. Resolves the vault with the same precedence as `obsidian-mcp` and currently provides initialization, full-document sync for open buffers, in-memory note shadowing through `Vault::load_note()` / `unload_note()`, health diagnostics for broken links and duplicate IDs or aliases, hover metadata for note links, document links with resolve support, backlinks-based references, and go-to-definition for note links, heading anchors, and nested sub-anchors via `tower-lsp` and `tokio`.
 
 ## Workspace Structure
 
@@ -35,10 +35,10 @@ This file provides guidance to coding agents when working in this repository.
 - `obsidian-lsp/` — the LSP server binary crate
   - `src/main.rs` — entry point: parses CLI args, initializes error reporting/logging, resolves the vault, and starts the STDIO LSP server
   - `src/args.rs` — clap args and vault resolution helper for `--vault`, `OBSIDIAN_VAULT`, and `open_from_cwd()`
-  - `src/server.rs` — `Backend` implementation of `tower_lsp::LanguageServer` for initialize/open/change/close flows, diagnostics publication, and hover requests
-  - `src/state.rs` — shared backend state plus snapshot-based diagnostics and hover computation helpers
+  - `src/server.rs` — `Backend` implementation of `tower_lsp::LanguageServer` for initialize/open/change/close flows, diagnostics publication, hover, document links, references, and definition requests
+  - `src/state.rs` — shared backend state plus snapshot-based diagnostics and navigation computation helpers
   - `src/uri.rs` — file URI/path conversion helpers and vault-relative path validation
-  - `tests/lsp_integration.rs` — end-to-end stdio JSON-RPC harness covering initialize, diagnostics, hover, document sync notifications, shutdown, and exit
+  - `tests/lsp_integration.rs` — end-to-end stdio JSON-RPC harness covering initialize, diagnostics, hover, document links, references, definition, document sync notifications, shutdown, and exit
 
 ## Development
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added a real `obsidian-rs-lsp` stdio server using `tower-lsp`, including vault resolution via `--vault`, `OBSIDIAN_VAULT`, or `open_from_cwd()`, full-document buffer syncing into `Vault::load_note()` / `unload_note()`, workspace health diagnostics for broken links and duplicate IDs or aliases, link hover metadata, and end-to-end stdio integration coverage.
+- Added `check_vault` MCP tool: reports duplicate IDs, duplicate aliases, and broken links — equivalent to the CLI's `check` command. Accepts an optional `ignore` parameter (list of vault-relative glob patterns to exclude).
+- Added `Vault::check(filter: impl Fn(&Path) -> bool) -> VaultHealthReport` to `obsidian-rs-core`. Returns a `VaultHealthReport` with `duplicate_ids`, `duplicate_aliases`, and `broken_links` fields. Health report types (`VaultHealthReport`, `DuplicateId`, `DuplicateAlias`, `BrokenLink`, `NoteRef`) are exported from the `health` module.
+
 ### Fixed
 
 - Markdown links with percent-encoded URLs (e.g. `[text](My%20Note.md)`) are now correctly resolved for backlink detection, health checks, and rename/merge operations.
-
-### Added
-
-- Added `check_vault` MCP tool: reports duplicate IDs, duplicate aliases, and broken links — equivalent to the CLI's `check` command. Accepts an optional `ignore` parameter (list of vault-relative glob patterns to exclude).
-- Added `Vault::check(filter: impl Fn(&Path) -> bool) -> VaultHealthReport` to `obsidian-rs-core`. Returns a `VaultHealthReport` with `duplicate_ids`, `duplicate_aliases`, and `broken_links` fields. Health report types (`VaultHealthReport`, `DuplicateId`, `DuplicateAlias`, `BrokenLink`, `NoteRef`) are exported from the `health` module.
 
 ## v0.2.0 - 2026-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added a real `obsidian-rs-lsp` stdio server using `tower-lsp`, including vault resolution via `--vault`, `OBSIDIAN_VAULT`, or `open_from_cwd()`, full-document buffer syncing into `Vault::load_note()` / `unload_note()`, workspace health diagnostics for broken links and duplicate IDs or aliases, link hover metadata, and end-to-end stdio integration coverage.
+- Added a real `obsidian-rs-lsp` stdio server using `tower-lsp`, including vault resolution via `--vault`, `OBSIDIAN_VAULT`, or `open_from_cwd()`, full-document buffer syncing into `Vault::load_note()` / `unload_note()`, workspace health diagnostics for broken links and duplicate IDs or aliases, link hover metadata, document links with resolve support, backlinks-based references, go-to-definition for note links, heading anchors, and nested sub-anchors, and end-to-end stdio integration coverage.
 - Added `check_vault` MCP tool: reports duplicate IDs, duplicate aliases, and broken links — equivalent to the CLI's `check` command. Accepts an optional `ignore` parameter (list of vault-relative glob patterns to exclude).
 - Added `Vault::check(filter: impl Fn(&Path) -> bool) -> VaultHealthReport` to `obsidian-rs-core`. Returns a `VaultHealthReport` with `duplicate_ids`, `duplicate_aliases`, and `broken_links` fields. Health report types (`VaultHealthReport`, `DuplicateId`, `DuplicateAlias`, `BrokenLink`, `NoteRef`) are exported from the `health` module.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +160,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -357,10 +374,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -435,6 +476,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -569,6 +619,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -598,6 +654,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +684,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +776,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -714,6 +879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +898,19 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lsp-types"
+version = "0.94.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
 
 [[package]]
 name = "matchers"
@@ -835,7 +1019,16 @@ dependencies = [
 name = "obsidian-rs-lsp"
 version = "0.2.0"
 dependencies = [
+ "clap",
+ "color-eyre",
  "obsidian-rs-core",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tower-lsp",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -904,10 +1097,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "predicates"
@@ -999,7 +1227,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1098,7 +1326,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1219,6 +1447,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,6 +1518,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +1538,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1344,6 +1600,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1649,66 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-lsp"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "dashmap",
+ "futures",
+ "httparse",
+ "lsp-types",
+ "memchr",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-lsp-macros",
+ "tracing",
+]
+
+[[package]]
+name = "tower-lsp-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1472,6 +1798,25 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1601,7 +1946,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1742,7 +2087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -1773,6 +2118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "yaml-rust2"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +2132,83 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A collection of tools for working with [Obsidian](https://obsidian.md) vaults, w
 | [`obsidian-rs-core`](https://crates.io/crates/obsidian-rs-core) | Core library — the foundation the other tools build on |
 | [`obsidian-rs-cli`](https://crates.io/crates/obsidian-rs-cli) | Command-line tool for querying and managing vaults |
 | [`obsidian-rs-mcp`](https://crates.io/crates/obsidian-rs-mcp) | MCP server so agents can interact with your vault |
-| `obsidian-rs-lsp` | **(WIP)** Language server for vault editing in your IDE |
+| `obsidian-rs-lsp` | **(WIP)** Language server skeleton for vault editing in your IDE |
 
 ## CLI
 
@@ -97,6 +97,27 @@ claude mcp add obsidian --scope project obsidian-mcp --vault .
 | `rename_note` | Rename a note and update all backlinks |
 | `list_tags` | List all tags used in the vault |
 | `search_tags` | Find all occurrences of given tags |
+
+## LSP Server
+
+Install with Cargo:
+
+```sh
+cargo install obsidian-rs-lsp
+```
+
+The `obsidian-lsp` binary speaks stdio LSP and resolves the vault the same way as `obsidian-mcp`: `--vault <PATH>`, then `OBSIDIAN_VAULT`, then the nearest parent containing `.obsidian/`.
+
+Current functionality:
+
+- clean LSP initialization and shutdown
+- full-document text sync for open buffers
+- in-memory buffer shadowing through `obsidian_core::Vault::load_note()` / `unload_note()`
+- diagnostics for broken links, duplicate IDs, and duplicate aliases across the vault
+- hover on note links with basic target-note metadata
+- diagnostics clearing and refresh on open/change/close events
+
+Advanced editor features such as go-to-definition, rename, and completion are not implemented yet.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A collection of tools for working with [Obsidian](https://obsidian.md) vaults, w
 | [`obsidian-rs-core`](https://crates.io/crates/obsidian-rs-core) | Core library — the foundation the other tools build on |
 | [`obsidian-rs-cli`](https://crates.io/crates/obsidian-rs-cli) | Command-line tool for querying and managing vaults |
 | [`obsidian-rs-mcp`](https://crates.io/crates/obsidian-rs-mcp) | MCP server so agents can interact with your vault |
-| `obsidian-rs-lsp` | **(WIP)** Language server skeleton for vault editing in your IDE |
+| [`obsidian-rs-lsp`](https://crates.io/crates/obsidian-rs-lsp) | A language server for vault editing in your IDE |
 
 ## CLI
 
@@ -121,16 +121,6 @@ Current functionality:
 - diagnostics clearing and refresh on open/change/close events
 
 Advanced editor features such as rename and completion are not implemented yet.
-
-## Roadmap
-
-- [x] Core library
-- [x] CLI tool
-- [x] MCP server
-- [ ] More core features
-  - [ ] Additional search/filter capabilities
-- [ ] LSP server
-  - [x] Go-to definition
 
 ## On the use of AI
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,12 @@ Current functionality:
 - in-memory buffer shadowing through `obsidian_core::Vault::load_note()` / `unload_note()`
 - diagnostics for broken links, duplicate IDs, and duplicate aliases across the vault
 - hover on note links with basic target-note metadata
+- document links for wiki and markdown note links, with resolve support
+- references/backlinks for linked notes, or for the current note when the cursor is not on a link
+- go-to definition for linked notes, including heading anchors and nested sub-anchors
 - diagnostics clearing and refresh on open/change/close events
 
-Advanced editor features such as go-to-definition, rename, and completion are not implemented yet.
+Advanced editor features such as rename and completion are not implemented yet.
 
 ## Roadmap
 
@@ -127,7 +130,7 @@ Advanced editor features such as go-to-definition, rename, and completion are no
 - [ ] More core features
   - [ ] Additional search/filter capabilities
 - [ ] LSP server
-  - [ ] Go-to definition
+  - [x] Go-to definition
 
 ## On the use of AI
 

--- a/obsidian-cli/tests/cli.rs
+++ b/obsidian-cli/tests/cli.rs
@@ -1513,7 +1513,7 @@ fn merge_dry_run_json_format() {
     let s = String::from_utf8(output).unwrap();
     let v: serde_json::Value = serde_json::from_str(&s).unwrap();
     assert!(v["dest_path"].as_str().unwrap().contains("combined.md"));
-    assert_eq!(v["dest_is_new"].as_bool().unwrap(), true);
+    assert!(v["dest_is_new"].as_bool().unwrap());
     assert!(v["sources"].as_array().unwrap().len() == 2);
     let updated = v["updated_notes"].as_array().unwrap();
     assert_eq!(updated.len(), 1);

--- a/obsidian-core/src/common.rs
+++ b/obsidian-core/src/common.rs
@@ -18,7 +18,7 @@ pub struct InlineLocation {
 }
 
 /// Normalizes a path by resolving `.`, `..`, and symlink components and making absolute.
-pub(crate) fn normalize_path(path: impl AsRef<Path>, root: Option<&Path>) -> PathBuf {
+pub fn normalize_path(path: impl AsRef<Path>, root: Option<&Path>) -> PathBuf {
     let path = if path.as_ref().is_absolute() {
         path.as_ref().to_path_buf()
     } else {
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn normalize_path_removes_dot() {
         assert_eq!(
-            normalize_path(&PathBuf::from("/a/./b"), Some(&current_dir().unwrap())),
+            normalize_path(PathBuf::from("/a/./b"), Some(&current_dir().unwrap())),
             PathBuf::from("/a/b")
         );
     }
@@ -152,14 +152,14 @@ mod tests {
     #[test]
     fn normalize_path_resolves_double_dot() {
         let cwd = current_dir().unwrap();
-        assert_eq!(normalize_path(&cwd.join("../c"), None), cwd.parent().unwrap().join("c"));
+        assert_eq!(normalize_path(cwd.join("../c"), None), cwd.parent().unwrap().join("c"));
     }
 
     #[test]
     fn normalize_path_deep_traversal() {
         let cwd = current_dir().unwrap();
         assert_eq!(
-            normalize_path(&cwd.join("../../../d"), None),
+            normalize_path(cwd.join("../../../d"), None),
             cwd.parent().unwrap().parent().unwrap().parent().unwrap().join("d")
         );
     }
@@ -168,7 +168,7 @@ mod tests {
     fn normalize_path_traversal_beyond_root_stops_at_root() {
         let cwd = current_dir().unwrap();
         assert_eq!(
-            normalize_path(&cwd.join("../../../../../../b"), None),
+            normalize_path(cwd.join("../../../../../../b"), None),
             PathBuf::from("/b")
         );
     }
@@ -176,14 +176,14 @@ mod tests {
     #[test]
     fn normalize_path_starting_with_single_dot() {
         let cwd = current_dir().unwrap();
-        assert_eq!(normalize_path(&PathBuf::from("./b"), Some(&cwd.clone())), cwd.join("b"));
+        assert_eq!(normalize_path(PathBuf::from("./b"), Some(&cwd)), cwd.join("b"));
     }
 
     #[test]
     fn normalize_path_starting_with_double_dot() {
         let cwd = current_dir().unwrap();
         assert_eq!(
-            normalize_path(&PathBuf::from("../b"), Some(&cwd.clone())),
+            normalize_path(PathBuf::from("../b"), Some(&cwd)),
             cwd.parent().unwrap().join("b")
         );
     }

--- a/obsidian-core/src/lib.rs
+++ b/obsidian-core/src/lib.rs
@@ -1,4 +1,4 @@
-mod common;
+pub mod common;
 mod error;
 pub mod health;
 mod link;

--- a/obsidian-core/src/note.rs
+++ b/obsidian-core/src/note.rs
@@ -838,7 +838,7 @@ mod tests {
             on_disk,
             format!(
                 "---\nid: {}\n---\n\n{}",
-                tmp.path().file_stem().unwrap().display().to_string(),
+                tmp.path().file_stem().unwrap().display(),
                 original
             )
         );

--- a/obsidian-core/src/vault.rs
+++ b/obsidian-core/src/vault.rs
@@ -990,7 +990,7 @@ mod tests {
     fn open_valid_directory() {
         let dir = tempfile::tempdir().unwrap();
         // std::fs::create_dir(&dir).unwrap();
-        let vault = Vault::open(&dir.path()).expect("should open valid directory");
+        let vault = Vault::open(dir.path()).expect("should open valid directory");
         assert_eq!(vault.path, common::normalize_path(dir.path(), None));
     }
 
@@ -1512,7 +1512,7 @@ mod tests {
 
         assert_eq!(
             preview.new_path,
-            common::normalize_path(&dir.path().join("new.md"), None)
+            common::normalize_path(dir.path().join("new.md"), None)
         );
         assert!(preview.updated_notes.is_empty());
         assert!(preview.id_will_update);
@@ -1872,7 +1872,7 @@ mod tests {
 
         let vault = Vault::open(dir.path()).unwrap();
         let src = Note::from_path_with_body(dir.path().join("src.md")).unwrap();
-        vault.merge_preview(&[src], &dir.path().join("dest.md")).unwrap();
+        vault.merge_preview(&[src], dir.path().join("dest.md")).unwrap();
 
         assert!(dir.path().join("src.md").exists());
         assert!(!dir.path().join("dest.md").exists());

--- a/obsidian-lsp/Cargo.toml
+++ b/obsidian-lsp/Cargo.toml
@@ -15,3 +15,14 @@ path = "src/main.rs"
 
 [dependencies]
 obsidian-rs-core = { path = "../obsidian-core", version = "0.2.0" }
+clap = { version = "4", features = ["derive"] }
+color-eyre = "0.6"
+thiserror = "2"
+tokio = { version = "1", features = ["full"] }
+tower-lsp = "0.20"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+serde_json = "1"
+tempfile = "3"

--- a/obsidian-lsp/Cargo.toml
+++ b/obsidian-lsp/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 obsidian-rs-core = { path = "../obsidian-core", version = "0.2.0" }
 clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6"
+serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tower-lsp = "0.20"
@@ -24,5 +25,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-serde_json = "1"
 tempfile = "3"

--- a/obsidian-lsp/src/args.rs
+++ b/obsidian-lsp/src/args.rs
@@ -1,0 +1,88 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use obsidian_core::{Vault, VaultError};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "obsidian-lsp",
+    about = "Language Server Protocol server for an Obsidian vault"
+)]
+pub struct Args {
+    /// Path to the Obsidian vault. Overrides the OBSIDIAN_VAULT environment variable.
+    #[arg(long)]
+    pub vault: Option<PathBuf>,
+}
+
+pub fn resolve_vault_path(cli_vault: Option<PathBuf>, env_vault: Option<PathBuf>) -> Result<PathBuf, VaultError> {
+    if let Some(path) = cli_vault {
+        return Ok(path);
+    }
+    if let Some(path) = env_vault {
+        return Ok(path);
+    }
+
+    Ok(Vault::open_from_cwd()?.path().to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use std::sync::{LazyLock, Mutex};
+
+    static CWD_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    struct CurrentDirGuard(PathBuf);
+
+    impl CurrentDirGuard {
+        fn change_to(path: &Path) -> Self {
+            let original = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self(original)
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.0).unwrap();
+        }
+    }
+
+    #[test]
+    fn resolve_vault_path_prefers_cli_arg() {
+        let cli_vault = PathBuf::from("/tmp/cli-vault");
+        let env_vault = PathBuf::from("/tmp/env-vault");
+
+        let resolved = resolve_vault_path(Some(cli_vault.clone()), Some(env_vault)).unwrap();
+
+        assert_eq!(resolved, cli_vault);
+    }
+
+    #[test]
+    fn resolve_vault_path_falls_back_to_env_var() {
+        let env_vault = PathBuf::from("/tmp/env-vault");
+
+        let resolved = resolve_vault_path(None, Some(env_vault.clone())).unwrap();
+
+        assert_eq!(resolved, env_vault);
+    }
+
+    #[test]
+    fn resolve_vault_path_falls_back_to_nearest_obsidian_dir() {
+        let _cwd_guard = CWD_LOCK.lock().unwrap();
+        let vault_dir = tempfile::tempdir().unwrap();
+        let nested_dir = vault_dir.path().join("notes/daily");
+        fs::create_dir_all(&nested_dir).unwrap();
+        fs::create_dir(vault_dir.path().join(".obsidian")).unwrap();
+        let _current_dir = CurrentDirGuard::change_to(&nested_dir);
+
+        let resolved = resolve_vault_path(None, None).unwrap();
+
+        assert_eq!(
+            resolved.canonicalize().unwrap(),
+            vault_dir.path().canonicalize().unwrap()
+        );
+    }
+}

--- a/obsidian-lsp/src/main.rs
+++ b/obsidian-lsp/src/main.rs
@@ -1,3 +1,33 @@
-fn main() {
-    println!("Hello, World!")
+mod args;
+mod server;
+mod state;
+mod uri;
+
+use std::path::PathBuf;
+
+use clap::Parser;
+use tower_lsp::{LspService, Server};
+
+#[tokio::main]
+async fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
+
+    // All logging goes to stderr — stdout is reserved for the JSON-RPC stream.
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args = args::Args::parse();
+    let vault_path = args::resolve_vault_path(args.vault, std::env::var("OBSIDIAN_VAULT").ok().map(PathBuf::from))
+        .map_err(|error| color_eyre::eyre::eyre!("could not find vault: {error}"))?;
+    let vault = obsidian_core::Vault::open(&vault_path)
+        .map_err(|error| color_eyre::eyre::eyre!("failed to open vault: {error}"))?;
+
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+    let (service, socket) = LspService::new(move |client| server::Backend::new(client, vault));
+    Server::new(stdin, stdout, socket).serve(service).await;
+
+    Ok(())
 }

--- a/obsidian-lsp/src/server.rs
+++ b/obsidian-lsp/src/server.rs
@@ -4,14 +4,18 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::{
-    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, Hover, HoverParams,
-    HoverProviderCapability, InitializeParams, InitializeResult, InitializedParams, MessageType, ServerCapabilities,
-    ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind, WorkspaceFoldersServerCapabilities,
-    WorkspaceServerCapabilities,
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, DocumentLink,
+    DocumentLinkOptions, DocumentLinkParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
+    HoverProviderCapability, InitializeParams, InitializeResult, InitializedParams, Location, MessageType, OneOf,
+    ReferenceParams, ServerCapabilities, ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind,
+    WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities,
 };
 use tower_lsp::{Client, LanguageServer};
 
-use crate::state::{BackendState, DiagnosticUpdate, DiagnosticsRequest, HoverRequest, StateError};
+use crate::state::{
+    BackendState, DiagnosticUpdate, DiagnosticsRequest, DocumentLinksRequest, NavigationRequest,
+    ResolveDocumentLinkRequest, StateError,
+};
 
 pub struct Backend {
     client: Client,
@@ -78,7 +82,23 @@ impl Backend {
         }
     }
 
-    async fn compute_hover(&self, request: std::result::Result<HoverRequest, StateError>) -> Option<Hover> {
+    async fn compute_hover(&self, request: std::result::Result<NavigationRequest, StateError>) -> Option<Hover> {
+        self.compute_request(request, "hover", |request| request.compute_hover())
+            .await
+            .flatten()
+    }
+
+    async fn compute_request<Request, Output, Compute>(
+        &self,
+        request: std::result::Result<Request, StateError>,
+        label: &'static str,
+        compute: Compute,
+    ) -> Option<Output>
+    where
+        Request: Send + 'static,
+        Output: Send + 'static,
+        Compute: FnOnce(Request) -> std::result::Result<Output, StateError> + Send + 'static,
+    {
         let request = match request {
             Ok(request) => request,
             Err(error) => {
@@ -87,14 +107,14 @@ impl Backend {
             }
         };
 
-        match tokio::task::spawn_blocking(move || request.compute()).await {
-            Ok(Ok(hover)) => hover,
+        match tokio::task::spawn_blocking(move || compute(request)).await {
+            Ok(Ok(output)) => Some(output),
             Ok(Err(error)) => {
                 self.log_error(error).await;
                 None
             }
             Err(error) => {
-                self.log_error(format!("hover task failed: {error}")).await;
+                self.log_error(format!("{label} task failed: {error}")).await;
                 None
             }
         }
@@ -108,6 +128,12 @@ impl LanguageServer for Backend {
             capabilities: ServerCapabilities {
                 text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
+                document_link_provider: Some(DocumentLinkOptions {
+                    resolve_provider: Some(true),
+                    work_done_progress_options: Default::default(),
+                }),
+                references_provider: Some(OneOf::Left(true)),
+                definition_provider: Some(OneOf::Left(true)),
                 workspace: Some(WorkspaceServerCapabilities {
                     workspace_folders: Some(WorkspaceFoldersServerCapabilities {
                         supported: Some(false),
@@ -176,12 +202,76 @@ impl LanguageServer for Backend {
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
         let request = {
             let state = self.state.read().await;
-            state.hover_request(
+            state.navigation_request(
                 params.text_document_position_params.text_document.uri,
                 params.text_document_position_params.position,
             )
         };
 
         Ok(self.compute_hover(request).await)
+    }
+
+    async fn document_link(&self, params: DocumentLinkParams) -> Result<Option<Vec<DocumentLink>>> {
+        let request = {
+            let state = self.state.read().await;
+            state.document_links_request(params.text_document.uri)
+        };
+
+        Ok(self
+            .compute_request(request, "documentLink", |request: DocumentLinksRequest| {
+                request.compute()
+            })
+            .await)
+    }
+
+    async fn document_link_resolve(&self, params: DocumentLink) -> Result<DocumentLink> {
+        let fallback = params.clone();
+        let request = {
+            let state = self.state.read().await;
+            state.resolve_document_link_request(params)
+        };
+
+        Ok(self
+            .compute_request(
+                request,
+                "documentLink/resolve",
+                |request: ResolveDocumentLinkRequest| request.compute(),
+            )
+            .await
+            .unwrap_or(fallback))
+    }
+
+    async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
+        let request = {
+            let state = self.state.read().await;
+            state.navigation_request(
+                params.text_document_position.text_document.uri,
+                params.text_document_position.position,
+            )
+        };
+
+        Ok(self
+            .compute_request(request, "references", |request: NavigationRequest| {
+                request.compute_references()
+            })
+            .await
+            .flatten())
+    }
+
+    async fn goto_definition(&self, params: GotoDefinitionParams) -> Result<Option<GotoDefinitionResponse>> {
+        let request = {
+            let state = self.state.read().await;
+            state.navigation_request(
+                params.text_document_position_params.text_document.uri,
+                params.text_document_position_params.position,
+            )
+        };
+
+        Ok(self
+            .compute_request(request, "definition", |request: NavigationRequest| {
+                request.compute_definition()
+            })
+            .await
+            .flatten())
     }
 }

--- a/obsidian-lsp/src/server.rs
+++ b/obsidian-lsp/src/server.rs
@@ -1,0 +1,187 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::{Mutex, RwLock};
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::{
+    DidChangeTextDocumentParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams, Hover, HoverParams,
+    HoverProviderCapability, InitializeParams, InitializeResult, InitializedParams, MessageType, ServerCapabilities,
+    ServerInfo, TextDocumentSyncCapability, TextDocumentSyncKind, WorkspaceFoldersServerCapabilities,
+    WorkspaceServerCapabilities,
+};
+use tower_lsp::{Client, LanguageServer};
+
+use crate::state::{BackendState, DiagnosticUpdate, DiagnosticsRequest, HoverRequest, StateError};
+
+pub struct Backend {
+    client: Client,
+    state: Arc<RwLock<BackendState>>,
+    diagnostics_lock: Arc<Mutex<()>>,
+}
+
+impl Backend {
+    pub fn new(client: Client, vault: obsidian_core::Vault) -> Self {
+        Self {
+            client,
+            state: Arc::new(RwLock::new(BackendState::new(vault))),
+            diagnostics_lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    async fn publish_diagnostics(&self, updates: &[DiagnosticUpdate]) {
+        for update in updates {
+            self.client
+                .publish_diagnostics(update.uri.clone(), update.diagnostics.clone(), update.version)
+                .await;
+        }
+    }
+
+    async fn log_error(&self, error: impl std::fmt::Display) {
+        self.client.log_message(MessageType::ERROR, error.to_string()).await;
+    }
+
+    async fn vault_path(&self) -> PathBuf {
+        self.state.read().await.vault_path().to_path_buf()
+    }
+
+    async fn handle_diagnostics(&self, request: std::result::Result<DiagnosticsRequest, StateError>) {
+        let request = match request {
+            Ok(request) => request,
+            Err(error) => {
+                self.log_error(error).await;
+                return;
+            }
+        };
+
+        let _guard = self.diagnostics_lock.lock().await;
+        let batch = match tokio::task::spawn_blocking(move || request.compute()).await {
+            Ok(Ok(batch)) => batch,
+            Ok(Err(error)) => {
+                self.log_error(error).await;
+                return;
+            }
+            Err(error) => {
+                self.log_error(format!("diagnostics task failed: {error}")).await;
+                return;
+            }
+        };
+
+        if self.state.read().await.diagnostics_revision() != batch.revision {
+            return;
+        }
+
+        self.publish_diagnostics(&batch.updates).await;
+
+        let mut state = self.state.write().await;
+        if state.diagnostics_revision() == batch.revision {
+            state.set_published_diagnostics(batch.published_diagnostics);
+        }
+    }
+
+    async fn compute_hover(&self, request: std::result::Result<HoverRequest, StateError>) -> Option<Hover> {
+        let request = match request {
+            Ok(request) => request,
+            Err(error) => {
+                self.log_error(error).await;
+                return None;
+            }
+        };
+
+        match tokio::task::spawn_blocking(move || request.compute()).await {
+            Ok(Ok(hover)) => hover,
+            Ok(Err(error)) => {
+                self.log_error(error).await;
+                None
+            }
+            Err(error) => {
+                self.log_error(format!("hover task failed: {error}")).await;
+                None
+            }
+        }
+    }
+}
+
+#[tower_lsp::async_trait]
+impl LanguageServer for Backend {
+    async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
+        Ok(InitializeResult {
+            capabilities: ServerCapabilities {
+                text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
+                hover_provider: Some(HoverProviderCapability::Simple(true)),
+                workspace: Some(WorkspaceServerCapabilities {
+                    workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                        supported: Some(false),
+                        change_notifications: None,
+                    }),
+                    file_operations: None,
+                }),
+                ..Default::default()
+            },
+            server_info: Some(ServerInfo {
+                name: env!("CARGO_PKG_NAME").to_string(),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            }),
+        })
+    }
+
+    async fn initialized(&self, _: InitializedParams) {
+        let vault_path = self.vault_path().await;
+        self.client
+            .log_message(
+                MessageType::INFO,
+                format!("obsidian-lsp ready for vault {}", vault_path.display()),
+            )
+            .await;
+    }
+
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let request = {
+            let mut state = self.state.write().await;
+            state.open_document(
+                params.text_document.uri,
+                params.text_document.version,
+                params.text_document.text,
+            )
+        };
+
+        self.handle_diagnostics(request).await;
+    }
+
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let request = {
+            let mut state = self.state.write().await;
+            state.change_document(
+                params.text_document.uri,
+                params.text_document.version,
+                &params.content_changes,
+            )
+        };
+
+        self.handle_diagnostics(request).await;
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let request = {
+            let mut state = self.state.write().await;
+            state.close_document(params.text_document.uri)
+        };
+
+        self.handle_diagnostics(request).await;
+    }
+
+    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
+        let request = {
+            let state = self.state.read().await;
+            state.hover_request(
+                params.text_document_position_params.text_document.uri,
+                params.text_document_position_params.position,
+            )
+        };
+
+        Ok(self.compute_hover(request).await)
+    }
+}

--- a/obsidian-lsp/src/state.rs
+++ b/obsidian-lsp/src/state.rs
@@ -1,0 +1,902 @@
+use std::collections::{BTreeSet, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use obsidian_core::search;
+use obsidian_core::{
+    BrokenLink, DuplicateAlias, DuplicateId, InlineLocation, Link, Note, NoteError, Vault, VaultError,
+};
+use thiserror::Error;
+use tower_lsp::lsp_types::{
+    Diagnostic, DiagnosticSeverity, Hover, HoverContents, MarkupContent, MarkupKind, NumberOrString, Position, Range,
+    TextDocumentContentChangeEvent, Url,
+};
+
+use crate::uri::{UriError, path_to_uri, uri_to_path, vault_relative_path};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct OpenDocument {
+    pub uri: Url,
+    pub path: PathBuf,
+    pub version: i32,
+    pub text: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct DiagnosticUpdate {
+    pub uri: Url,
+    pub version: Option<i32>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug)]
+pub struct DiagnosticsBatch {
+    pub revision: u64,
+    pub updates: Vec<DiagnosticUpdate>,
+    pub published_diagnostics: HashMap<PathBuf, Url>,
+}
+
+#[derive(Clone, Debug)]
+struct StateSnapshot {
+    vault_path: PathBuf,
+    open_documents: HashMap<PathBuf, OpenDocument>,
+}
+
+#[derive(Debug)]
+pub struct DiagnosticsRequest {
+    snapshot: StateSnapshot,
+    previously_published: HashMap<PathBuf, Url>,
+    primary_document: PrimaryDocument,
+    revision: u64,
+}
+
+#[derive(Debug)]
+pub struct HoverRequest {
+    snapshot: StateSnapshot,
+    path: PathBuf,
+    position: Position,
+}
+
+#[derive(Debug)]
+struct PrimaryDocument {
+    path: PathBuf,
+    uri: Url,
+    version: Option<i32>,
+}
+
+#[derive(Debug, Error)]
+pub enum StateError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Note(#[from] NoteError),
+    #[error(transparent)]
+    Uri(#[from] UriError),
+    #[error(transparent)]
+    Vault(#[from] VaultError),
+    #[error("didChange for '{uri}' did not include full document content")]
+    MissingDocumentContent { uri: Url },
+}
+
+pub struct BackendState {
+    vault: Vault,
+    open_documents: HashMap<PathBuf, OpenDocument>,
+    published_diagnostics: HashMap<PathBuf, Url>,
+    diagnostics_revision: u64,
+}
+
+impl BackendState {
+    pub fn new(vault: Vault) -> Self {
+        Self {
+            vault,
+            open_documents: HashMap::new(),
+            published_diagnostics: HashMap::new(),
+            diagnostics_revision: 0,
+        }
+    }
+
+    pub fn vault_path(&self) -> &Path {
+        self.vault.path()
+    }
+
+    pub fn diagnostics_revision(&self) -> u64 {
+        self.diagnostics_revision
+    }
+
+    pub fn set_published_diagnostics(&mut self, published_diagnostics: HashMap<PathBuf, Url>) {
+        self.published_diagnostics = published_diagnostics;
+    }
+
+    pub fn open_document(&mut self, uri: Url, version: i32, text: String) -> Result<DiagnosticsRequest, StateError> {
+        self.sync_document(uri, version, text)
+    }
+
+    pub fn change_document(
+        &mut self,
+        uri: Url,
+        version: i32,
+        changes: &[TextDocumentContentChangeEvent],
+    ) -> Result<DiagnosticsRequest, StateError> {
+        let text = changes
+            .last()
+            .map(|change| change.text.clone())
+            .ok_or_else(|| StateError::MissingDocumentContent { uri: uri.clone() })?;
+
+        self.sync_document(uri, version, text)
+    }
+
+    pub fn close_document(&mut self, uri: Url) -> Result<DiagnosticsRequest, StateError> {
+        let path = self.path_from_uri(&uri)?;
+        self.open_documents.remove(&path);
+        self.vault.unload_note(&path);
+
+        Ok(self.prepare_diagnostics_request(path, uri, None))
+    }
+
+    pub fn hover_request(&self, uri: Url, position: Position) -> Result<HoverRequest, StateError> {
+        let path = self.path_from_uri(&uri)?;
+
+        Ok(HoverRequest {
+            snapshot: self.snapshot(),
+            path,
+            position,
+        })
+    }
+
+    fn sync_document(&mut self, uri: Url, version: i32, text: String) -> Result<DiagnosticsRequest, StateError> {
+        let path = self.path_from_uri(&uri)?;
+
+        self.vault.load_note(Note::parse(&path, &text));
+        self.open_documents.insert(
+            path.clone(),
+            OpenDocument {
+                uri: uri.clone(),
+                path: path.clone(),
+                version,
+                text,
+            },
+        );
+
+        Ok(self.prepare_diagnostics_request(path, uri, Some(version)))
+    }
+
+    fn prepare_diagnostics_request(&mut self, path: PathBuf, uri: Url, version: Option<i32>) -> DiagnosticsRequest {
+        self.diagnostics_revision += 1;
+
+        DiagnosticsRequest {
+            snapshot: self.snapshot(),
+            previously_published: self.published_diagnostics.clone(),
+            primary_document: PrimaryDocument { path, uri, version },
+            revision: self.diagnostics_revision,
+        }
+    }
+
+    fn snapshot(&self) -> StateSnapshot {
+        StateSnapshot {
+            vault_path: self.vault.path().to_path_buf(),
+            open_documents: self.open_documents.clone(),
+        }
+    }
+
+    fn path_from_uri(&self, uri: &Url) -> Result<PathBuf, StateError> {
+        let path = uri_to_path(uri)?;
+        vault_relative_path(self.vault.path(), &path)?;
+        Ok(path)
+    }
+}
+
+impl DiagnosticsRequest {
+    pub fn compute(self) -> Result<DiagnosticsBatch, StateError> {
+        let vault = self.snapshot.build_vault()?;
+        let report = vault.check(|_| true);
+        let mut diagnostics_by_path = build_diagnostics_by_path(&self.snapshot, &report)?;
+
+        let mut paths_to_publish = BTreeSet::new();
+        paths_to_publish.extend(diagnostics_by_path.keys().cloned());
+        paths_to_publish.extend(self.previously_published.keys().cloned());
+        paths_to_publish.insert(self.primary_document.path.clone());
+
+        let mut published_diagnostics = HashMap::new();
+        let mut updates = Vec::with_capacity(paths_to_publish.len());
+
+        for path in paths_to_publish {
+            let uri = if path == self.primary_document.path {
+                self.primary_document.uri.clone()
+            } else {
+                self.snapshot.uri_for_path(&path)?
+            };
+            let version = if path == self.primary_document.path {
+                self.primary_document.version
+            } else {
+                self.snapshot.version_for_path(&path)
+            };
+            let diagnostics = diagnostics_by_path.remove(&path).unwrap_or_default();
+
+            if !diagnostics.is_empty() {
+                published_diagnostics.insert(path.clone(), uri.clone());
+            }
+
+            updates.push(DiagnosticUpdate {
+                uri,
+                version,
+                diagnostics,
+            });
+        }
+
+        Ok(DiagnosticsBatch {
+            revision: self.revision,
+            updates,
+            published_diagnostics,
+        })
+    }
+}
+
+impl HoverRequest {
+    pub fn compute(self) -> Result<Option<Hover>, StateError> {
+        let vault = self.snapshot.build_vault()?;
+        let source_note = self.snapshot.note_for_path(&self.path)?;
+        let Some(hovered_link) = source_note
+            .links
+            .iter()
+            .find(|link| position_in_location(self.position, &link.location))
+        else {
+            return Ok(None);
+        };
+
+        let notes: Vec<Note> = vault
+            .notes_filtered(|_| true)
+            .into_iter()
+            .filter_map(Result::ok)
+            .collect();
+        let matching_notes: Vec<&Note> = notes
+            .iter()
+            .filter(|note| {
+                search::find_matching_links(&source_note, note, vault.path())
+                    .iter()
+                    .any(|candidate| same_location(&candidate.location, &hovered_link.location))
+            })
+            .collect();
+
+        if matching_notes.is_empty() {
+            return Ok(None);
+        }
+
+        let contents = if matching_notes.len() == 1 {
+            render_note_hover(matching_notes[0], self.snapshot.vault_path.as_path())
+        } else {
+            render_ambiguous_hover(&matching_notes, self.snapshot.vault_path.as_path())
+        };
+
+        Ok(Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: contents,
+            }),
+            range: Some(location_to_range(&hovered_link.location)),
+        }))
+    }
+}
+
+impl StateSnapshot {
+    fn build_vault(&self) -> Result<Vault, StateError> {
+        let mut vault = Vault::open(&self.vault_path)?;
+        for document in self.open_documents.values() {
+            vault.load_note(Note::parse(&document.path, &document.text));
+        }
+        Ok(vault)
+    }
+
+    fn note_for_path(&self, path: &Path) -> Result<Note, StateError> {
+        if let Some(document) = self.open_documents.get(path) {
+            Ok(Note::parse(path, &document.text))
+        } else {
+            Ok(Note::from_path(path)?)
+        }
+    }
+
+    fn text_for_path(&self, path: &Path) -> Result<String, StateError> {
+        if let Some(document) = self.open_documents.get(path) {
+            Ok(document.text.clone())
+        } else {
+            Ok(fs::read_to_string(path)?)
+        }
+    }
+
+    fn uri_for_path(&self, path: &Path) -> Result<Url, StateError> {
+        if let Some(document) = self.open_documents.get(path) {
+            Ok(document.uri.clone())
+        } else {
+            Ok(path_to_uri(path)?)
+        }
+    }
+
+    fn version_for_path(&self, path: &Path) -> Option<i32> {
+        self.open_documents.get(path).map(|document| document.version)
+    }
+}
+
+fn build_diagnostics_by_path(
+    snapshot: &StateSnapshot,
+    report: &obsidian_core::VaultHealthReport,
+) -> Result<HashMap<PathBuf, Vec<Diagnostic>>, StateError> {
+    let mut diagnostics_by_path: HashMap<PathBuf, Vec<Diagnostic>> = HashMap::new();
+
+    for duplicate in &report.duplicate_ids {
+        add_duplicate_id_diagnostics(snapshot, &mut diagnostics_by_path, duplicate)?;
+    }
+
+    for duplicate in &report.duplicate_aliases {
+        add_duplicate_alias_diagnostics(snapshot, &mut diagnostics_by_path, duplicate)?;
+    }
+
+    add_broken_link_diagnostics(snapshot, &mut diagnostics_by_path, &report.broken_links)?;
+
+    for diagnostics in diagnostics_by_path.values_mut() {
+        diagnostics.sort_by(|left, right| {
+            left.range
+                .start
+                .line
+                .cmp(&right.range.start.line)
+                .then(left.range.start.character.cmp(&right.range.start.character))
+                .then(left.message.cmp(&right.message))
+        });
+    }
+
+    Ok(diagnostics_by_path)
+}
+
+fn add_duplicate_id_diagnostics(
+    snapshot: &StateSnapshot,
+    diagnostics_by_path: &mut HashMap<PathBuf, Vec<Diagnostic>>,
+    duplicate: &DuplicateId,
+) -> Result<(), StateError> {
+    for note in &duplicate.notes {
+        let other_paths = duplicate
+            .notes
+            .iter()
+            .filter(|candidate| candidate.path != note.path)
+            .map(|candidate| relative_display(snapshot.vault_path.as_path(), &candidate.path))
+            .collect::<Vec<_>>();
+
+        diagnostics_by_path
+            .entry(note.path.clone())
+            .or_default()
+            .push(make_diagnostic(
+                duplicate_id_range(snapshot, &note.path)?,
+                "duplicate-id",
+                format!(
+                    "Duplicate note ID `{}` also used by {}.",
+                    duplicate.id,
+                    other_paths.join(", ")
+                ),
+            ));
+    }
+
+    Ok(())
+}
+
+fn add_duplicate_alias_diagnostics(
+    snapshot: &StateSnapshot,
+    diagnostics_by_path: &mut HashMap<PathBuf, Vec<Diagnostic>>,
+    duplicate: &DuplicateAlias,
+) -> Result<(), StateError> {
+    for note in &duplicate.notes {
+        let other_paths = duplicate
+            .notes
+            .iter()
+            .filter(|candidate| candidate.path != note.path)
+            .map(|candidate| relative_display(snapshot.vault_path.as_path(), &candidate.path))
+            .collect::<Vec<_>>();
+
+        diagnostics_by_path
+            .entry(note.path.clone())
+            .or_default()
+            .push(make_diagnostic(
+                duplicate_alias_range(snapshot, &note.path, &duplicate.alias)?,
+                "duplicate-alias",
+                format!(
+                    "Duplicate alias `{}` also used by {}.",
+                    duplicate.alias,
+                    other_paths.join(", ")
+                ),
+            ));
+    }
+
+    Ok(())
+}
+
+fn add_broken_link_diagnostics(
+    snapshot: &StateSnapshot,
+    diagnostics_by_path: &mut HashMap<PathBuf, Vec<Diagnostic>>,
+    broken_links: &[BrokenLink],
+) -> Result<(), StateError> {
+    let mut note_cache: HashMap<PathBuf, Note> = HashMap::new();
+    let mut used_ranges: HashMap<PathBuf, Vec<Range>> = HashMap::new();
+
+    for broken in broken_links {
+        let note = match note_cache.get(&broken.source_path) {
+            Some(note) => note,
+            None => {
+                let note = snapshot.note_for_path(&broken.source_path)?;
+                note_cache.insert(broken.source_path.clone(), note);
+                note_cache.get(&broken.source_path).unwrap()
+            }
+        };
+        let range = find_broken_link_range(note, broken, used_ranges.entry(broken.source_path.clone()).or_default())
+            .unwrap_or_else(|| line_start_range(broken.line));
+
+        diagnostics_by_path
+            .entry(broken.source_path.clone())
+            .or_default()
+            .push(make_diagnostic(
+                range,
+                "broken-link",
+                format!("Broken link {}.", broken.text),
+            ));
+    }
+
+    Ok(())
+}
+
+fn find_broken_link_range(note: &Note, broken: &BrokenLink, used_ranges: &mut Vec<Range>) -> Option<Range> {
+    for link in &note.links {
+        let range = location_to_range(&link.location);
+        if used_ranges.contains(&range) {
+            continue;
+        }
+        if link.location.line != broken.line || !link_matches_broken(link, broken) {
+            continue;
+        }
+
+        used_ranges.push(range);
+        return Some(range);
+    }
+
+    None
+}
+
+fn link_matches_broken(link: &obsidian_core::LocatedLink, broken: &BrokenLink) -> bool {
+    match &link.link {
+        Link::Wiki { target, .. } => broken.text == format!("[[{}]]", target),
+        Link::Markdown { url, .. } => broken.text == format!("[...]({})", url),
+        Link::Embed { .. } => false,
+    }
+}
+
+fn duplicate_id_range(snapshot: &StateSnapshot, path: &Path) -> Result<Range, StateError> {
+    let text = snapshot.text_for_path(path)?;
+    Ok(find_frontmatter_key_range(&text, "id").unwrap_or_else(document_start_range))
+}
+
+fn duplicate_alias_range(snapshot: &StateSnapshot, path: &Path, alias: &str) -> Result<Range, StateError> {
+    let text = snapshot.text_for_path(path)?;
+    Ok(find_alias_range(&text, alias).unwrap_or_else(document_start_range))
+}
+
+fn find_frontmatter_key_range(text: &str, key: &str) -> Option<Range> {
+    let mut lines = text.lines();
+    if lines.next()? != "---" {
+        return None;
+    }
+
+    for (line_index, line) in text.lines().enumerate().skip(1) {
+        if line == "---" {
+            break;
+        }
+        if let Some(col_start) = line.find(&format!("{key}:")) {
+            return Some(range_for_span(line_index, col_start, key.len()));
+        }
+    }
+
+    None
+}
+
+fn find_alias_range(text: &str, alias: &str) -> Option<Range> {
+    find_frontmatter_value_range(text, alias).or_else(|| find_title_or_heading_range(text, alias))
+}
+
+fn find_frontmatter_value_range(text: &str, value: &str) -> Option<Range> {
+    let mut lines = text.lines();
+    if lines.next()? != "---" {
+        return None;
+    }
+
+    for (line_index, line) in text.lines().enumerate().skip(1) {
+        if line == "---" {
+            break;
+        }
+        if let Some(col_start) = line.find(value) {
+            return Some(range_for_span(line_index, col_start, value.chars().count()));
+        }
+    }
+
+    None
+}
+
+fn find_title_or_heading_range(text: &str, value: &str) -> Option<Range> {
+    for (line_index, line) in text.lines().enumerate() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with("title:") && !trimmed.starts_with("# ") {
+            continue;
+        }
+        if let Some(col_start) = line.find(value) {
+            return Some(range_for_span(line_index, col_start, value.chars().count()));
+        }
+    }
+
+    None
+}
+
+fn make_diagnostic(range: Range, code: &str, message: String) -> Diagnostic {
+    Diagnostic {
+        range,
+        severity: Some(DiagnosticSeverity::WARNING),
+        code: Some(NumberOrString::String(code.to_string())),
+        source: Some("obsidian-lsp".to_string()),
+        message,
+        ..Default::default()
+    }
+}
+
+fn render_note_hover(note: &Note, vault_path: &Path) -> String {
+    let mut lines = Vec::new();
+    let heading = note.title.as_deref().unwrap_or(note.id.as_str());
+    lines.push(format!("**{}**", heading));
+    lines.push(String::new());
+    lines.push(format!("- Path: `{}`", relative_display(vault_path, &note.path)));
+    lines.push(format!("- ID: `{}`", note.id));
+
+    if !note.aliases.is_empty() {
+        lines.push(format!("- Aliases: {}", markdown_list(note.aliases.iter().cloned())));
+    }
+
+    let tags = note
+        .tags
+        .iter()
+        .map(|tag| tag.tag.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    if !tags.is_empty() {
+        lines.push(format!("- Tags: {}", markdown_list(tags)));
+    }
+
+    lines.join("\n")
+}
+
+fn render_ambiguous_hover(notes: &[&Note], vault_path: &Path) -> String {
+    let mut lines = vec![
+        "**Ambiguous note link**".to_string(),
+        String::new(),
+        "This link matches more than one note:".to_string(),
+        String::new(),
+    ];
+
+    for note in notes {
+        lines.push(format!("- `{}`", relative_display(vault_path, &note.path)));
+    }
+
+    lines.join("\n")
+}
+
+fn markdown_list(items: impl IntoIterator<Item = String>) -> String {
+    items
+        .into_iter()
+        .map(|item| format!("`{}`", item))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn relative_display(vault_path: &Path, path: &Path) -> String {
+    path.strip_prefix(vault_path).unwrap_or(path).display().to_string()
+}
+
+fn position_in_location(position: Position, location: &InlineLocation) -> bool {
+    let line = position.line + 1;
+    let character = position.character;
+
+    line == location.line as u32 && character >= location.col_start as u32 && character < location.col_end as u32
+}
+
+fn same_location(left: &InlineLocation, right: &InlineLocation) -> bool {
+    left.line == right.line && left.col_start == right.col_start && left.col_end == right.col_end
+}
+
+fn location_to_range(location: &InlineLocation) -> Range {
+    Range::new(
+        Position::new((location.line.saturating_sub(1)) as u32, location.col_start as u32),
+        Position::new((location.line.saturating_sub(1)) as u32, location.col_end as u32),
+    )
+}
+
+fn line_start_range(line: usize) -> Range {
+    Range::new(
+        Position::new((line.saturating_sub(1)) as u32, 0),
+        Position::new((line.saturating_sub(1)) as u32, 0),
+    )
+}
+
+fn document_start_range() -> Range {
+    Range::new(Position::new(0, 0), Position::new(0, 0))
+}
+
+fn range_for_span(line: usize, col_start: usize, width: usize) -> Range {
+    Range::new(
+        Position::new(line as u32, col_start as u32),
+        Position::new(line as u32, (col_start + width) as u32),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uri::path_to_uri;
+
+    fn open_state() -> (tempfile::TempDir, BackendState, PathBuf, Url) {
+        let vault_dir = tempfile::tempdir().unwrap();
+        fs::create_dir(vault_dir.path().join(".obsidian")).unwrap();
+
+        let note_path = vault_dir.path().join("notes/today.md");
+        fs::create_dir_all(note_path.parent().unwrap()).unwrap();
+        fs::write(&note_path, "disk body").unwrap();
+        let note_path = note_path.canonicalize().unwrap();
+
+        let vault = Vault::open(vault_dir.path()).unwrap();
+        let state = BackendState::new(vault);
+        let uri = path_to_uri(&note_path).unwrap();
+
+        (vault_dir, state, note_path, uri)
+    }
+
+    fn note_body(state: &BackendState, note_path: &Path) -> Option<String> {
+        state
+            .vault
+            .notes_filtered_with_content(|candidate| candidate == note_path)
+            .into_iter()
+            .find_map(Result::ok)
+            .and_then(|note| note.body)
+    }
+
+    fn update_for_uri<'a>(batch: &'a DiagnosticsBatch, uri: &Url) -> &'a DiagnosticUpdate {
+        batch
+            .updates
+            .iter()
+            .find(|update| update.uri == *uri)
+            .expect("batch should contain a diagnostics update for the requested URI")
+    }
+
+    fn codes(update: &DiagnosticUpdate) -> Vec<&str> {
+        update
+            .diagnostics
+            .iter()
+            .filter_map(|diagnostic| diagnostic.code.as_ref())
+            .filter_map(|code| match code {
+                NumberOrString::String(value) => Some(value.as_str()),
+                NumberOrString::Number(_) => None,
+            })
+            .collect()
+    }
+
+    fn position_for_substring(text: &str, needle: &str) -> Position {
+        for (line_index, line) in text.lines().enumerate() {
+            if let Some(col_start) = line.find(needle) {
+                return Position::new(line_index as u32, col_start as u32 + 2);
+            }
+        }
+
+        panic!("substring '{needle}' not found");
+    }
+
+    #[test]
+    fn open_document_loads_note_into_vault_state() {
+        let (_vault_dir, mut state, note_path, uri) = open_state();
+
+        let request = state.open_document(uri.clone(), 1, "buffer body".to_string()).unwrap();
+        let batch = request.compute().unwrap();
+        let update = update_for_uri(&batch, &uri);
+
+        assert_eq!(update.uri, uri);
+        assert_eq!(update.version, Some(1));
+        assert!(update.diagnostics.is_empty());
+        assert!(state.vault.note_is_loaded(&note_path));
+        assert_eq!(state.open_documents.get(&note_path).unwrap().text, "buffer body");
+        assert_eq!(note_body(&state, &note_path).as_deref(), Some("buffer body"));
+    }
+
+    #[test]
+    fn change_document_updates_in_memory_note_body() {
+        let (_vault_dir, mut state, note_path, uri) = open_state();
+        state.open_document(uri.clone(), 1, "buffer body".to_string()).unwrap();
+        let note_uri = uri.clone();
+
+        let request = state
+            .change_document(
+                uri,
+                2,
+                &[TextDocumentContentChangeEvent {
+                    range: None,
+                    range_length: None,
+                    text: "changed body".to_string(),
+                }],
+            )
+            .unwrap();
+        let batch = request.compute().unwrap();
+
+        assert_eq!(state.open_documents.get(&note_path).unwrap().version, 2);
+        assert_eq!(state.open_documents.get(&note_path).unwrap().text, "changed body");
+        assert_eq!(note_body(&state, &note_path).as_deref(), Some("changed body"));
+        assert_eq!(update_for_uri(&batch, &note_uri).version, Some(2));
+    }
+
+    #[test]
+    fn close_document_unloads_the_in_memory_override() {
+        let (_vault_dir, mut state, note_path, uri) = open_state();
+        state.open_document(uri.clone(), 1, "buffer body".to_string()).unwrap();
+
+        let request = state.close_document(uri.clone()).unwrap();
+        let batch = request.compute().unwrap();
+        let update = update_for_uri(&batch, &uri);
+
+        assert!(update.diagnostics.is_empty());
+        assert!(!state.vault.note_is_loaded(&note_path));
+        assert!(!state.open_documents.contains_key(&note_path));
+        assert_eq!(note_body(&state, &note_path).as_deref(), Some("disk body"));
+    }
+
+    #[test]
+    fn open_document_rejects_paths_outside_the_vault() {
+        let (_vault_dir, mut state, _note_path, _uri) = open_state();
+        let external_path = tempfile::tempdir().unwrap().path().join("external.md");
+        let external_uri = path_to_uri(&external_path).unwrap();
+
+        let error = state
+            .open_document(external_uri, 1, "buffer body".to_string())
+            .unwrap_err();
+
+        assert!(matches!(error, StateError::Uri(UriError::PathOutsideVault { .. })));
+    }
+
+    #[test]
+    fn change_document_requires_full_document_content() {
+        let (_vault_dir, mut state, _note_path, uri) = open_state();
+
+        let error = state.change_document(uri.clone(), 2, &[]).unwrap_err();
+
+        assert!(matches!(
+            error,
+            StateError::MissingDocumentContent { uri: actual } if actual == uri
+        ));
+    }
+
+    #[test]
+    fn open_document_reports_health_diagnostics_for_all_affected_notes() {
+        let vault_dir = tempfile::tempdir().unwrap();
+        fs::create_dir(vault_dir.path().join(".obsidian")).unwrap();
+
+        let note_a_path = vault_dir.path().join("note-a.md");
+        let note_a_text = "---\nid: shared-id\naliases: [shared-alias]\n---\n\nSee [[missing-note]].\n";
+        fs::write(&note_a_path, note_a_text).unwrap();
+        let note_a_path = note_a_path.canonicalize().unwrap();
+        let note_a_uri = path_to_uri(&note_a_path).unwrap();
+
+        let note_b_path = vault_dir.path().join("note-b.md");
+        fs::write(
+            &note_b_path,
+            "---\nid: shared-id\naliases: [shared-alias]\n---\n\nBody.\n",
+        )
+        .unwrap();
+        let note_b_path = note_b_path.canonicalize().unwrap();
+        let note_b_uri = path_to_uri(&note_b_path).unwrap();
+
+        let vault = Vault::open(vault_dir.path()).unwrap();
+        let mut state = BackendState::new(vault);
+        let batch = state
+            .open_document(note_a_uri.clone(), 1, note_a_text.to_string())
+            .unwrap()
+            .compute()
+            .unwrap();
+
+        let note_a_update = update_for_uri(&batch, &note_a_uri);
+        assert_eq!(note_a_update.version, Some(1));
+        assert_eq!(
+            codes(note_a_update),
+            vec!["duplicate-id", "duplicate-alias", "broken-link"]
+        );
+        assert!(
+            note_a_update
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("Broken link [[missing-note]]"))
+        );
+        assert!(
+            note_a_update
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.range.start.line == 5 && diagnostic.range.start.character == 4)
+        );
+
+        let note_b_update = update_for_uri(&batch, &note_b_uri);
+        assert_eq!(note_b_update.version, None);
+        assert_eq!(codes(note_b_update), vec!["duplicate-id", "duplicate-alias"]);
+    }
+
+    #[test]
+    fn hover_request_returns_metadata_for_wiki_links() {
+        let vault_dir = tempfile::tempdir().unwrap();
+        fs::create_dir(vault_dir.path().join(".obsidian")).unwrap();
+
+        let target_path = vault_dir.path().join("target.md");
+        fs::write(
+            &target_path,
+            "---\nid: target-id\ntitle: Target Note\naliases: [target-alias]\ntags: [rust]\n---\n\nBody.\n",
+        )
+        .unwrap();
+
+        let source_path = vault_dir.path().join("source.md");
+        fs::write(&source_path, "placeholder").unwrap();
+        let source_path = source_path.canonicalize().unwrap();
+        let source_uri = path_to_uri(&source_path).unwrap();
+        let source_text = "See [[target-id]].";
+
+        let vault = Vault::open(vault_dir.path()).unwrap();
+        let mut state = BackendState::new(vault);
+        state
+            .open_document(source_uri.clone(), 1, source_text.to_string())
+            .unwrap();
+
+        let hover = state
+            .hover_request(source_uri, position_for_substring(source_text, "[[target-id]]"))
+            .unwrap()
+            .compute()
+            .unwrap()
+            .unwrap();
+
+        let HoverContents::Markup(contents) = hover.contents else {
+            panic!("expected markdown hover contents");
+        };
+        assert!(contents.value.contains("Target Note"));
+        assert!(contents.value.contains("target-id"));
+        assert!(contents.value.contains("target-alias"));
+        assert!(contents.value.contains("rust"));
+    }
+
+    #[test]
+    fn hover_request_resolves_relative_markdown_links() {
+        let vault_dir = tempfile::tempdir().unwrap();
+        fs::create_dir(vault_dir.path().join(".obsidian")).unwrap();
+
+        let target_path = vault_dir.path().join("notes/target.md");
+        fs::create_dir_all(target_path.parent().unwrap()).unwrap();
+        fs::write(
+            &target_path,
+            "---\nid: target-id\ntitle: Target Note\naliases: [target-alias]\n---\n\nBody.\n",
+        )
+        .unwrap();
+
+        let source_path = vault_dir.path().join("journal/today.md");
+        fs::create_dir_all(source_path.parent().unwrap()).unwrap();
+        fs::write(&source_path, "placeholder").unwrap();
+        let source_path = source_path.canonicalize().unwrap();
+        let source_uri = path_to_uri(&source_path).unwrap();
+        let source_text = "See [Target](../notes/target.md).";
+
+        let vault = Vault::open(vault_dir.path()).unwrap();
+        let mut state = BackendState::new(vault);
+        state
+            .open_document(source_uri.clone(), 1, source_text.to_string())
+            .unwrap();
+
+        let hover = state
+            .hover_request(source_uri, position_for_substring(source_text, "../notes/target.md"))
+            .unwrap()
+            .compute()
+            .unwrap()
+            .unwrap();
+
+        let HoverContents::Markup(contents) = hover.contents else {
+            panic!("expected markdown hover contents");
+        };
+        assert!(contents.value.contains("Target Note"));
+        assert!(contents.value.contains("notes/target.md"));
+    }
+}

--- a/obsidian-lsp/src/state.rs
+++ b/obsidian-lsp/src/state.rs
@@ -2,14 +2,14 @@ use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use obsidian_core::search;
 use obsidian_core::{
-    BrokenLink, DuplicateAlias, DuplicateId, InlineLocation, Link, Note, NoteError, Vault, VaultError,
+    BrokenLink, DuplicateAlias, DuplicateId, InlineLocation, Link, LocatedLink, Note, NoteError, Vault, VaultError,
 };
+use serde_json::{Value, json};
 use thiserror::Error;
 use tower_lsp::lsp_types::{
-    Diagnostic, DiagnosticSeverity, Hover, HoverContents, MarkupContent, MarkupKind, NumberOrString, Position, Range,
-    TextDocumentContentChangeEvent, Url,
+    Diagnostic, DiagnosticSeverity, DocumentLink, GotoDefinitionResponse, Hover, HoverContents, Location,
+    MarkupContent, MarkupKind, NumberOrString, Position, Range, TextDocumentContentChangeEvent, Url,
 };
 
 use crate::uri::{UriError, path_to_uri, uri_to_path, vault_relative_path};
@@ -51,10 +51,33 @@ pub struct DiagnosticsRequest {
 }
 
 #[derive(Debug)]
-pub struct HoverRequest {
+pub struct DocumentLinksRequest {
+    snapshot: StateSnapshot,
+    path: PathBuf,
+    uri: Url,
+}
+
+#[derive(Debug)]
+pub struct ResolveDocumentLinkRequest {
+    snapshot: StateSnapshot,
+    source_path: PathBuf,
+    document_link: DocumentLink,
+    raw_link: String,
+}
+
+#[derive(Debug)]
+pub struct NavigationRequest {
     snapshot: StateSnapshot,
     path: PathBuf,
     position: Position,
+}
+
+struct NavigationContext {
+    snapshot: StateSnapshot,
+    vault: Vault,
+    notes: Vec<Note>,
+    source_note: Note,
+    selected_link: Option<LocatedLink>,
 }
 
 #[derive(Debug)]
@@ -63,6 +86,14 @@ struct PrimaryDocument {
     uri: Url,
     version: Option<i32>,
 }
+
+struct DocumentLinkData {
+    source_uri: String,
+    raw_link: String,
+}
+
+const DOCUMENT_LINK_SOURCE_URI_KEY: &str = "sourceUri";
+const DOCUMENT_LINK_RAW_LINK_KEY: &str = "rawLink";
 
 #[derive(Debug, Error)]
 pub enum StateError {
@@ -76,6 +107,8 @@ pub enum StateError {
     Vault(#[from] VaultError),
     #[error("didChange for '{uri}' did not include full document content")]
     MissingDocumentContent { uri: Url },
+    #[error("invalid document link data: {0}")]
+    InvalidDocumentLinkData(String),
 }
 
 pub struct BackendState {
@@ -133,10 +166,43 @@ impl BackendState {
         Ok(self.prepare_diagnostics_request(path, uri, None))
     }
 
-    pub fn hover_request(&self, uri: Url, position: Position) -> Result<HoverRequest, StateError> {
+    pub fn document_links_request(&self, uri: Url) -> Result<DocumentLinksRequest, StateError> {
         let path = self.path_from_uri(&uri)?;
 
-        Ok(HoverRequest {
+        Ok(DocumentLinksRequest {
+            snapshot: self.snapshot(),
+            path,
+            uri,
+        })
+    }
+
+    pub fn resolve_document_link_request(
+        &self,
+        document_link: DocumentLink,
+    ) -> Result<ResolveDocumentLinkRequest, StateError> {
+        let data = parse_document_link_data(
+            document_link
+                .data
+                .as_ref()
+                .ok_or_else(|| StateError::InvalidDocumentLinkData("missing documentLink.data".to_string()))?,
+        )?;
+        let source_uri = Url::parse(&data.source_uri).map_err(|error| {
+            StateError::InvalidDocumentLinkData(format!("invalid source URI '{}': {error}", data.source_uri))
+        })?;
+        let source_path = self.path_from_uri(&source_uri)?;
+
+        Ok(ResolveDocumentLinkRequest {
+            snapshot: self.snapshot(),
+            source_path,
+            document_link,
+            raw_link: data.raw_link,
+        })
+    }
+
+    pub fn navigation_request(&self, uri: Url, position: Position) -> Result<NavigationRequest, StateError> {
+        let path = self.path_from_uri(&uri)?;
+
+        Ok(NavigationRequest {
             snapshot: self.snapshot(),
             path,
             position,
@@ -231,40 +297,78 @@ impl DiagnosticsRequest {
     }
 }
 
-impl HoverRequest {
-    pub fn compute(self) -> Result<Option<Hover>, StateError> {
-        let vault = self.snapshot.build_vault()?;
+impl DocumentLinksRequest {
+    pub fn compute(self) -> Result<Vec<DocumentLink>, StateError> {
         let source_note = self.snapshot.note_for_path(&self.path)?;
-        let Some(hovered_link) = source_note
+
+        Ok(source_note
             .links
             .iter()
-            .find(|link| position_in_location(self.position, &link.location))
-        else {
+            .filter_map(|link| build_document_link(&self.uri, link))
+            .collect())
+    }
+}
+
+impl ResolveDocumentLinkRequest {
+    pub fn compute(mut self) -> Result<DocumentLink, StateError> {
+        let source_note = synthetic_note_for_raw_link(&self.source_path, &self.raw_link)?;
+        let link = source_note.links.first().ok_or_else(|| {
+            StateError::InvalidDocumentLinkData("raw link did not parse into a supported link".to_string())
+        })?;
+
+        if let Some(target) = direct_document_link_target(&self.source_path, link, self.snapshot.vault_path.as_path())?
+        {
+            self.document_link.target = Some(target);
+            self.document_link.tooltip = Some(render_document_link_tooltip(
+                Some("Resolved external or file link"),
+                None,
+            ));
+            return Ok(self.document_link);
+        }
+
+        let vault = self.snapshot.build_vault()?;
+        let notes = self.snapshot.notes(&vault);
+        let matching_notes = resolve_link_targets(&source_note.path, &link.link, &notes, vault.path());
+
+        match matching_notes.as_slice() {
+            [] => {
+                self.document_link.tooltip = Some(render_document_link_tooltip(Some("Broken note link"), None));
+            }
+            [note] => {
+                self.document_link.target = Some(note_target_uri(note, &link.link)?);
+                self.document_link.tooltip = Some(render_document_link_tooltip(
+                    Some("Resolved note link"),
+                    Some(render_note_link_label(note, self.snapshot.vault_path.as_path())),
+                ));
+            }
+            notes => {
+                self.document_link.tooltip = Some(render_ambiguous_document_link_tooltip(
+                    notes,
+                    self.snapshot.vault_path.as_path(),
+                ));
+            }
+        }
+
+        Ok(self.document_link)
+    }
+}
+
+impl NavigationRequest {
+    pub fn compute_hover(self) -> Result<Option<Hover>, StateError> {
+        let context = self.build_context()?;
+        let Some(selected_link) = context.selected_link.as_ref() else {
             return Ok(None);
         };
-
-        let notes: Vec<Note> = vault
-            .notes_filtered(|_| true)
-            .into_iter()
-            .filter_map(Result::ok)
-            .collect();
-        let matching_notes: Vec<&Note> = notes
-            .iter()
-            .filter(|note| {
-                search::find_matching_links(&source_note, note, vault.path())
-                    .iter()
-                    .any(|candidate| same_location(&candidate.location, &hovered_link.location))
-            })
-            .collect();
+        let matching_notes = context.resolve_selected_link_targets();
 
         if matching_notes.is_empty() {
             return Ok(None);
         }
 
         let contents = if matching_notes.len() == 1 {
-            render_note_hover(matching_notes[0], self.snapshot.vault_path.as_path())
+            render_note_hover(matching_notes[0], context.snapshot.vault_path.as_path())
         } else {
-            render_ambiguous_hover(&matching_notes, self.snapshot.vault_path.as_path())
+            render_ambiguous_hover(&matching_notes, context.snapshot.vault_path.as_path())
         };
 
         Ok(Some(Hover {
@@ -272,8 +376,99 @@ impl HoverRequest {
                 kind: MarkupKind::Markdown,
                 value: contents,
             }),
-            range: Some(location_to_range(&hovered_link.location)),
+            range: Some(location_to_range(&selected_link.location)),
         }))
+    }
+
+    pub fn compute_references(self) -> Result<Option<Vec<Location>>, StateError> {
+        let context = self.build_context()?;
+        let target_notes = if context.selected_link.is_some() {
+            let matching = context.resolve_selected_link_targets();
+            if matching.len() != 1 {
+                return Ok(Some(Vec::new()));
+            }
+            vec![matching[0]]
+        } else {
+            // Obsidian-specific behavior: when the cursor is not on a link, treat
+            // references as backlinks to the current note.
+            vec![&context.source_note]
+        };
+
+        let mut locations = Vec::new();
+        for target in target_notes {
+            for (source_note, links) in context.vault.backlinks_from(&context.notes, target) {
+                let uri = context.snapshot.uri_for_path(&source_note.path)?;
+                locations.extend(links.into_iter().map(|link| Location {
+                    uri: uri.clone(),
+                    range: location_to_range(&link.location),
+                }));
+            }
+        }
+
+        locations.sort_by(|left, right| {
+            left.uri
+                .cmp(&right.uri)
+                .then(left.range.start.line.cmp(&right.range.start.line))
+                .then(left.range.start.character.cmp(&right.range.start.character))
+        });
+        locations.dedup_by(|left, right| left.uri == right.uri && left.range == right.range);
+
+        Ok(Some(locations))
+    }
+
+    pub fn compute_definition(self) -> Result<Option<GotoDefinitionResponse>, StateError> {
+        let context = self.build_context()?;
+        let matching_notes = context.resolve_selected_link_targets();
+        if matching_notes.is_empty() {
+            return Ok(None);
+        }
+
+        let mut locations = matching_notes
+            .into_iter()
+            .map(|note| {
+                note_location(
+                    &context.snapshot,
+                    note,
+                    selected_link_fragment(context.selected_link.as_ref()),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        locations.sort_by(|left, right| {
+            left.uri
+                .cmp(&right.uri)
+                .then(left.range.start.line.cmp(&right.range.start.line))
+                .then(left.range.start.character.cmp(&right.range.start.character))
+        });
+
+        Ok(Some(if locations.len() == 1 {
+            GotoDefinitionResponse::Scalar(locations.remove(0))
+        } else {
+            GotoDefinitionResponse::Array(locations)
+        }))
+    }
+
+    fn build_context(self) -> Result<NavigationContext, StateError> {
+        let vault = self.snapshot.build_vault()?;
+        let notes = self.snapshot.notes(&vault);
+        let source_note = self.snapshot.note_for_path(&self.path)?;
+        let selected_link = find_link_at_position(&source_note, self.position).cloned();
+
+        Ok(NavigationContext {
+            snapshot: self.snapshot,
+            vault,
+            notes,
+            source_note,
+            selected_link,
+        })
+    }
+}
+
+impl NavigationContext {
+    fn resolve_selected_link_targets(&self) -> Vec<&Note> {
+        self.selected_link
+            .as_ref()
+            .map(|link| resolve_link_targets(&self.source_note.path, &link.link, &self.notes, self.vault.path()))
+            .unwrap_or_default()
     }
 }
 
@@ -284,6 +479,14 @@ impl StateSnapshot {
             vault.load_note(Note::parse(&document.path, &document.text));
         }
         Ok(vault)
+    }
+
+    fn notes(&self, vault: &Vault) -> Vec<Note> {
+        vault
+            .notes_filtered(|_| true)
+            .into_iter()
+            .filter_map(Result::ok)
+            .collect()
     }
 
     fn note_for_path(&self, path: &Path) -> Result<Note, StateError> {
@@ -538,6 +741,431 @@ fn make_diagnostic(range: Range, code: &str, message: String) -> Diagnostic {
     }
 }
 
+fn build_document_link(source_uri: &Url, link: &LocatedLink) -> Option<DocumentLink> {
+    Some(DocumentLink {
+        range: location_to_range(&link.location),
+        target: None,
+        tooltip: None,
+        data: Some(json!({
+            DOCUMENT_LINK_SOURCE_URI_KEY: source_uri.as_str(),
+            DOCUMENT_LINK_RAW_LINK_KEY: render_link_text(&link.link)?,
+        })),
+    })
+}
+
+fn parse_document_link_data(value: &Value) -> Result<DocumentLinkData, StateError> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| StateError::InvalidDocumentLinkData("documentLink.data was not a JSON object".to_string()))?;
+    let source_uri = object
+        .get(DOCUMENT_LINK_SOURCE_URI_KEY)
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            StateError::InvalidDocumentLinkData(format!(
+                "documentLink.data did not include a string '{DOCUMENT_LINK_SOURCE_URI_KEY}'"
+            ))
+        })?;
+    let raw_link = object
+        .get(DOCUMENT_LINK_RAW_LINK_KEY)
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            StateError::InvalidDocumentLinkData(format!(
+                "documentLink.data did not include a string '{DOCUMENT_LINK_RAW_LINK_KEY}'"
+            ))
+        })?;
+
+    Ok(DocumentLinkData {
+        source_uri: source_uri.to_string(),
+        raw_link: raw_link.to_string(),
+    })
+}
+
+fn synthetic_note_for_raw_link(source_path: &Path, raw_link: &str) -> Result<Note, StateError> {
+    let note = Note::parse(source_path, raw_link);
+    if note.links.is_empty() {
+        return Err(StateError::InvalidDocumentLinkData(
+            "raw link did not parse into a wiki or markdown link".to_string(),
+        ));
+    }
+
+    Ok(note)
+}
+
+fn render_link_text(link: &Link) -> Option<String> {
+    match link {
+        Link::Wiki { target, heading, alias } => {
+            let mut text = format!("[[{target}");
+            if let Some(heading) = heading {
+                text.push('#');
+                text.push_str(heading);
+            }
+            if let Some(alias) = alias {
+                text.push('|');
+                text.push_str(alias);
+            }
+            text.push_str("]]");
+            Some(text)
+        }
+        Link::Markdown { text, url } => Some(format!("[{text}]({url})")),
+        Link::Embed { .. } => None,
+    }
+}
+
+fn direct_document_link_target(
+    source_path: &Path,
+    link: &LocatedLink,
+    vault_path: &Path,
+) -> Result<Option<Url>, StateError> {
+    match &link.link {
+        Link::Markdown { url, .. } => {
+            if url.contains("://") {
+                return Ok(Url::parse(url).ok());
+            }
+
+            let Some(path) = resolve_local_file_target_path(source_path, url, vault_path) else {
+                return Ok(None);
+            };
+
+            Ok(Some(path_to_uri(&path)?))
+        }
+        Link::Wiki { .. } | Link::Embed { .. } => Ok(None),
+    }
+}
+
+fn resolve_local_file_target_path(source_path: &Path, url: &str, vault_path: &Path) -> Option<PathBuf> {
+    let path = markdown_url_path(url)?;
+    if path.ends_with(".md") {
+        return None;
+    }
+
+    local_markdown_candidates(source_path, &path, vault_path)
+        .into_iter()
+        .find(|candidate| candidate.exists())
+}
+
+fn resolve_link_targets<'a>(source_path: &Path, link: &Link, notes: &'a [Note], vault_path: &Path) -> Vec<&'a Note> {
+    match link {
+        Link::Wiki { target, .. } => {
+            if target.is_empty() {
+                return Vec::new();
+            }
+
+            notes
+                .iter()
+                .filter(|note| note_matches_wiki_target(note, target))
+                .collect()
+        }
+        Link::Markdown { url, .. } => {
+            let Some(url_path) = markdown_url_path(url) else {
+                return Vec::new();
+            };
+            if !url_path.ends_with(".md") {
+                return Vec::new();
+            }
+
+            let candidates = local_markdown_candidates(source_path, &url_path, vault_path);
+            notes.iter().filter(|note| candidates.contains(&note.path)).collect()
+        }
+        Link::Embed { .. } => Vec::new(),
+    }
+}
+
+fn note_matches_wiki_target(note: &Note, target: &str) -> bool {
+    note.id == target
+        || note
+            .path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .is_some_and(|stem| stem == target)
+        || note.aliases.iter().any(|alias| alias == target)
+}
+
+fn local_markdown_candidates(source_path: &Path, url_path: &str, vault_path: &Path) -> Vec<PathBuf> {
+    let source_dir = source_path.parent().unwrap_or(source_path);
+    let mut candidates = vec![
+        obsidian_core::common::normalize_path(source_dir.join(url_path), Some(vault_path)),
+        obsidian_core::common::normalize_path(url_path, Some(vault_path)),
+    ];
+    candidates.dedup();
+    candidates
+}
+
+fn markdown_url_path(url: &str) -> Option<String> {
+    if url.contains("://") || url.starts_with('/') {
+        return None;
+    }
+
+    let url_path_raw = match url.find('#') {
+        Some(index) => &url[..index],
+        None => url,
+    };
+
+    Some(percent_decode(url_path_raw))
+}
+
+fn link_fragment(link: &Link) -> Option<String> {
+    match link {
+        Link::Wiki { heading, .. } => heading.clone(),
+        Link::Markdown { url, .. } => url
+            .split_once('#')
+            .map(|(_, fragment)| percent_decode(fragment))
+            .filter(|fragment| !fragment.is_empty()),
+        Link::Embed { .. } => None,
+    }
+}
+
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let (Some(high), Some(low)) = (
+                (bytes[index + 1] as char).to_digit(16),
+                (bytes[index + 2] as char).to_digit(16),
+            )
+        {
+            output.push((high * 16 + low) as u8);
+            index += 3;
+            continue;
+        }
+
+        output.push(bytes[index]);
+        index += 1;
+    }
+
+    String::from_utf8(output).unwrap_or_else(|_| input.to_string())
+}
+
+fn selected_link_fragment(link: Option<&LocatedLink>) -> Option<String> {
+    link.and_then(|link| link_fragment(&link.link))
+}
+
+fn note_target_uri(note: &Note, link: &Link) -> Result<Url, StateError> {
+    let mut uri = path_to_uri(&note.path)?;
+    if let Some(fragment) = link_fragment(link) {
+        uri.set_fragment(Some(&fragment));
+    }
+    Ok(uri)
+}
+
+fn note_location(snapshot: &StateSnapshot, note: &Note, fragment: Option<String>) -> Result<Location, StateError> {
+    let mut uri = path_to_uri(&note.path)?;
+    if let Some(fragment) = fragment.as_deref() {
+        uri.set_fragment(Some(fragment));
+    }
+
+    Ok(Location {
+        uri,
+        range: note_definition_range(snapshot, note, fragment.as_deref())?,
+    })
+}
+
+fn note_definition_range(snapshot: &StateSnapshot, note: &Note, fragment: Option<&str>) -> Result<Range, StateError> {
+    let text = snapshot.text_for_path(&note.path)?;
+
+    if let Some(fragment) = fragment
+        && let Some(range) = find_heading_range(&text, fragment)
+    {
+        return Ok(range);
+    }
+
+    if let Some(title) = note.title.as_deref()
+        && let Some(range) = find_title_or_heading_range(&text, title)
+    {
+        return Ok(range);
+    }
+
+    if let Some(range) = find_frontmatter_key_range(&text, "id") {
+        return Ok(range);
+    }
+
+    Ok(document_start_range())
+}
+
+struct HeadingFragmentSegment<'a> {
+    raw: &'a str,
+    normalized: String,
+}
+
+struct HeadingPathSegment<'a> {
+    text: &'a str,
+    normalized_anchor: String,
+    resolved_anchor: String,
+}
+
+fn find_heading_range(text: &str, heading: &str) -> Option<Range> {
+    let expected_segments = parse_heading_fragment_segments(heading);
+    if expected_segments.is_empty() {
+        return None;
+    }
+
+    let mut seen_anchors = HashMap::new();
+    let mut current_path = Vec::new();
+
+    for (line_index, line) in text.lines().enumerate() {
+        let Some((level, col_start, heading_text)) = heading_line_parts(line) else {
+            continue;
+        };
+        let Some(resolved_anchor) = resolve_heading_anchor(heading_text, &mut seen_anchors) else {
+            continue;
+        };
+
+        current_path.truncate(level.saturating_sub(1));
+        current_path.push(HeadingPathSegment {
+            text: heading_text,
+            normalized_anchor: normalize_heading_anchor(heading_text),
+            resolved_anchor,
+        });
+
+        if heading_path_matches(&current_path, &expected_segments) {
+            return Some(range_for_span(line_index, col_start, heading_text.chars().count()));
+        }
+    }
+
+    None
+}
+
+fn parse_heading_fragment_segments(heading: &str) -> Vec<HeadingFragmentSegment<'_>> {
+    heading
+        .split('#')
+        .filter(|segment| !segment.is_empty())
+        .map(|segment| HeadingFragmentSegment {
+            raw: segment,
+            normalized: normalize_heading_anchor(segment),
+        })
+        .collect()
+}
+
+fn heading_path_matches(path: &[HeadingPathSegment<'_>], expected: &[HeadingFragmentSegment<'_>]) -> bool {
+    if expected.len() > path.len() {
+        return false;
+    }
+
+    path[path.len() - expected.len()..]
+        .iter()
+        .zip(expected.iter())
+        .all(|(candidate, expected_segment)| heading_segment_matches(candidate, expected_segment))
+}
+
+fn heading_segment_matches(candidate: &HeadingPathSegment<'_>, expected: &HeadingFragmentSegment<'_>) -> bool {
+    candidate.text == expected.raw
+        || candidate.normalized_anchor == expected.normalized
+        || candidate.resolved_anchor == expected.normalized
+}
+
+fn heading_line_parts(line: &str) -> Option<(usize, usize, &str)> {
+    let trimmed = line.trim_start();
+    if !trimmed.starts_with('#') {
+        return None;
+    }
+
+    let marker_bytes = trimmed
+        .char_indices()
+        .take_while(|(_, ch)| *ch == '#')
+        .last()
+        .map_or(0, |(index, ch)| index + ch.len_utf8());
+    let level = trimmed[..marker_bytes].chars().count();
+    let after_markers = &trimmed[marker_bytes..];
+    let content = after_markers.trim_start();
+    if content.is_empty() {
+        return None;
+    }
+
+    let heading_text = strip_optional_heading_closing_hashes(content);
+    if heading_text.is_empty() {
+        return None;
+    }
+
+    let leading_bytes = line.len() - trimmed.len();
+    let whitespace_bytes = after_markers.len() - content.len();
+    let heading_start = leading_bytes + marker_bytes + whitespace_bytes;
+
+    Some((level, line[..heading_start].chars().count(), heading_text))
+}
+
+fn strip_optional_heading_closing_hashes(text: &str) -> &str {
+    let trimmed = text.trim_end();
+    let without_hashes = trimmed.trim_end_matches('#');
+    if without_hashes.len() == trimmed.len() || !without_hashes.chars().last().is_some_and(char::is_whitespace) {
+        return trimmed;
+    }
+
+    without_hashes.trim_end()
+}
+
+fn resolve_heading_anchor(heading_text: &str, seen_anchors: &mut HashMap<String, usize>) -> Option<String> {
+    let base_anchor = normalize_heading_anchor(heading_text);
+    if base_anchor.is_empty() {
+        return None;
+    }
+
+    let seen_count = seen_anchors.entry(base_anchor.clone()).or_default();
+    let anchor = if *seen_count == 0 {
+        base_anchor
+    } else {
+        format!("{base_anchor}-{seen_count}")
+    };
+    *seen_count += 1;
+
+    Some(anchor)
+}
+
+fn normalize_heading_anchor(text: &str) -> String {
+    let mut anchor = String::new();
+    let mut last_was_separator = true;
+
+    for ch in text.trim().chars().flat_map(char::to_lowercase) {
+        if ch.is_alphanumeric() || ch == '_' {
+            anchor.push(ch);
+            last_was_separator = false;
+        } else if (ch.is_whitespace() || ch == '-') && !last_was_separator && !anchor.is_empty() {
+            anchor.push('-');
+            last_was_separator = true;
+        }
+    }
+
+    while anchor.ends_with('-') {
+        anchor.pop();
+    }
+
+    anchor
+}
+
+fn find_link_at_position(note: &Note, position: Position) -> Option<&LocatedLink> {
+    note.links
+        .iter()
+        .filter(|link| !matches!(link.link, Link::Embed { .. }))
+        .find(|link| position_in_location(position, &link.location))
+}
+
+fn render_document_link_tooltip(prefix: Option<&str>, detail: Option<String>) -> String {
+    match (prefix, detail) {
+        (Some(prefix), Some(detail)) => format!("{prefix}: {detail}"),
+        (Some(prefix), None) => prefix.to_string(),
+        (None, Some(detail)) => detail,
+        (None, None) => "Obsidian link".to_string(),
+    }
+}
+
+fn render_ambiguous_document_link_tooltip(notes: &[&Note], vault_path: &Path) -> String {
+    format!(
+        "Ambiguous note link: {}",
+        notes
+            .iter()
+            .map(|note| relative_display(vault_path, &note.path))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn render_note_link_label(note: &Note, vault_path: &Path) -> String {
+    let title = note.title.as_deref().unwrap_or(note.id.as_str());
+    format!("{title} ({})", relative_display(vault_path, &note.path))
+}
+
 fn render_note_hover(note: &Note, vault_path: &Path) -> String {
     let mut lines = Vec::new();
     let heading = note.title.as_deref().unwrap_or(note.id.as_str());
@@ -596,10 +1224,6 @@ fn position_in_location(position: Position, location: &InlineLocation) -> bool {
     let character = position.character;
 
     line == location.line as u32 && character >= location.col_start as u32 && character < location.col_end as u32
-}
-
-fn same_location(left: &InlineLocation, right: &InlineLocation) -> bool {
-    left.line == right.line && left.col_start == right.col_start && left.col_end == right.col_end
 }
 
 fn location_to_range(location: &InlineLocation) -> Range {
@@ -820,8 +1444,7 @@ mod tests {
         assert_eq!(codes(note_b_update), vec!["duplicate-id", "duplicate-alias"]);
     }
 
-    #[test]
-    fn hover_request_returns_metadata_for_wiki_links() {
+    fn navigation_state() -> (tempfile::TempDir, BackendState, Url, Url, Url, String) {
         let vault_dir = tempfile::tempdir().unwrap();
         fs::create_dir(vault_dir.path().join(".obsidian")).unwrap();
 
@@ -831,12 +1454,17 @@ mod tests {
             "---\nid: target-id\ntitle: Target Note\naliases: [target-alias]\ntags: [rust]\n---\n\nBody.\n",
         )
         .unwrap();
+        let target_uri = path_to_uri(&target_path.canonicalize().unwrap()).unwrap();
 
         let source_path = vault_dir.path().join("source.md");
         fs::write(&source_path, "placeholder").unwrap();
         let source_path = source_path.canonicalize().unwrap();
         let source_uri = path_to_uri(&source_path).unwrap();
-        let source_text = "See [[target-id]].";
+        let source_text = "See [[target-id]] and [Target Markdown](target.md).";
+
+        let backlink_path = vault_dir.path().join("backlink.md");
+        fs::write(&backlink_path, "Another reference to [[target-id]].").unwrap();
+        let backlink_uri = path_to_uri(&backlink_path.canonicalize().unwrap()).unwrap();
 
         let vault = Vault::open(vault_dir.path()).unwrap();
         let mut state = BackendState::new(vault);
@@ -844,10 +1472,107 @@ mod tests {
             .open_document(source_uri.clone(), 1, source_text.to_string())
             .unwrap();
 
+        (
+            vault_dir,
+            state,
+            source_uri,
+            target_uri,
+            backlink_uri,
+            source_text.to_string(),
+        )
+    }
+
+    fn heading_anchor_navigation_state() -> (tempfile::TempDir, BackendState, Url, Url, String) {
+        let vault_dir = tempfile::tempdir().unwrap();
+        fs::create_dir(vault_dir.path().join(".obsidian")).unwrap();
+
+        let target_path = vault_dir.path().join("target.md");
+        fs::write(
+            &target_path,
+            "---\nid: target-id\ntitle: Target Note\n---\n\n# Overview\n\n## Linked Heading\nBody.\n",
+        )
+        .unwrap();
+        let target_uri = path_to_uri(&target_path.canonicalize().unwrap()).unwrap();
+
+        let source_path = vault_dir.path().join("source.md");
+        fs::write(&source_path, "placeholder").unwrap();
+        let source_path = source_path.canonicalize().unwrap();
+        let source_uri = path_to_uri(&source_path).unwrap();
+        let source_text = "See [[target-id#Linked Heading]] and [Target Markdown](target.md#linked-heading).";
+
+        let vault = Vault::open(vault_dir.path()).unwrap();
+        let mut state = BackendState::new(vault);
+        state
+            .open_document(source_uri.clone(), 1, source_text.to_string())
+            .unwrap();
+
+        (vault_dir, state, source_uri, target_uri, source_text.to_string())
+    }
+
+    fn nested_heading_anchor_navigation_state() -> (tempfile::TempDir, BackendState, Url, Url, String) {
+        let vault_dir = tempfile::tempdir().unwrap();
+        fs::create_dir(vault_dir.path().join(".obsidian")).unwrap();
+
+        let target_path = vault_dir.path().join("target.md");
+        fs::write(
+            &target_path,
+            concat!(
+                "---\n",
+                "id: target-id\n",
+                "title: Target Note\n",
+                "---\n",
+                "\n",
+                "# Other Heading\n",
+                "\n",
+                "## Subheading B\n",
+                "\n",
+                "# Heading A\n",
+                "\n",
+                "## Subheading B\n",
+                "Body.\n",
+            ),
+        )
+        .unwrap();
+        let target_uri = path_to_uri(&target_path.canonicalize().unwrap()).unwrap();
+
+        let source_path = vault_dir.path().join("source.md");
+        fs::write(&source_path, "placeholder").unwrap();
+        let source_path = source_path.canonicalize().unwrap();
+        let source_uri = path_to_uri(&source_path).unwrap();
+        let source_text = concat!(
+            "See [[target-id#Heading A#Subheading B]], ",
+            "[[target-id#heading-a#subheading-b]], ",
+            "and [Target Markdown](target.md#heading-a#subheading-b).\n"
+        );
+
+        let vault = Vault::open(vault_dir.path()).unwrap();
+        let mut state = BackendState::new(vault);
+        state
+            .open_document(source_uri.clone(), 1, source_text.to_string())
+            .unwrap();
+
+        (vault_dir, state, source_uri, target_uri, source_text.to_string())
+    }
+
+    fn document_link_for_raw_link(document_links: &[DocumentLink], raw_link: &str) -> DocumentLink {
+        document_links
+            .iter()
+            .find(|document_link| {
+                let data = parse_document_link_data(document_link.data.as_ref().unwrap()).unwrap();
+                data.raw_link == raw_link
+            })
+            .cloned()
+            .expect("document link should exist for the requested raw link")
+    }
+
+    #[test]
+    fn navigation_request_returns_metadata_for_wiki_links() {
+        let (_vault_dir, state, source_uri, _target_uri, _backlink_uri, source_text) = navigation_state();
+
         let hover = state
-            .hover_request(source_uri, position_for_substring(source_text, "[[target-id]]"))
+            .navigation_request(source_uri, position_for_substring(&source_text, "[[target-id]]"))
             .unwrap()
-            .compute()
+            .compute_hover()
             .unwrap()
             .unwrap();
 
@@ -861,7 +1586,7 @@ mod tests {
     }
 
     #[test]
-    fn hover_request_resolves_relative_markdown_links() {
+    fn navigation_request_resolves_relative_markdown_links() {
         let vault_dir = tempfile::tempdir().unwrap();
         fs::create_dir(vault_dir.path().join(".obsidian")).unwrap();
 
@@ -887,9 +1612,9 @@ mod tests {
             .unwrap();
 
         let hover = state
-            .hover_request(source_uri, position_for_substring(source_text, "../notes/target.md"))
+            .navigation_request(source_uri, position_for_substring(source_text, "../notes/target.md"))
             .unwrap()
-            .compute()
+            .compute_hover()
             .unwrap()
             .unwrap();
 
@@ -898,5 +1623,199 @@ mod tests {
         };
         assert!(contents.value.contains("Target Note"));
         assert!(contents.value.contains("notes/target.md"));
+    }
+
+    #[test]
+    fn document_links_request_lists_wiki_and_markdown_links() {
+        let (_vault_dir, state, source_uri, _target_uri, _backlink_uri, _source_text) = navigation_state();
+
+        let document_links = state.document_links_request(source_uri).unwrap().compute().unwrap();
+
+        assert_eq!(document_links.len(), 2);
+        assert!(
+            document_links
+                .iter()
+                .all(|document_link| document_link.target.is_none())
+        );
+        assert_eq!(
+            parse_document_link_data(document_links[0].data.as_ref().unwrap())
+                .unwrap()
+                .raw_link,
+            "[[target-id]]"
+        );
+        assert_eq!(
+            parse_document_link_data(document_links[1].data.as_ref().unwrap())
+                .unwrap()
+                .raw_link,
+            "[Target Markdown](target.md)"
+        );
+    }
+
+    #[test]
+    fn resolve_document_link_request_resolves_markdown_note_links() {
+        let (_vault_dir, state, source_uri, target_uri, _backlink_uri, _source_text) = navigation_state();
+        let document_links = state.document_links_request(source_uri).unwrap().compute().unwrap();
+        let markdown_link = document_link_for_raw_link(&document_links, "[Target Markdown](target.md)");
+
+        let resolved = state
+            .resolve_document_link_request(markdown_link)
+            .unwrap()
+            .compute()
+            .unwrap();
+
+        assert_eq!(resolved.target.as_ref(), Some(&target_uri));
+        assert!(resolved.tooltip.as_ref().unwrap().contains("Target Note"));
+    }
+
+    #[test]
+    fn navigation_request_returns_backlinks_for_current_note_when_off_link() {
+        let (_vault_dir, state, source_uri, target_uri, backlink_uri, _source_text) = navigation_state();
+
+        let references = state
+            .navigation_request(target_uri.clone(), Position::new(0, 0))
+            .unwrap()
+            .compute_references()
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(references.len(), 3);
+        assert_eq!(
+            references.iter().filter(|location| location.uri == source_uri).count(),
+            2
+        );
+        assert!(references.iter().any(|location| location.uri == backlink_uri));
+    }
+
+    #[test]
+    fn navigation_request_returns_definition_for_link_target() {
+        let (_vault_dir, state, source_uri, target_uri, _backlink_uri, source_text) = navigation_state();
+
+        let definition = state
+            .navigation_request(source_uri, position_for_substring(&source_text, "[[target-id]]"))
+            .unwrap()
+            .compute_definition()
+            .unwrap()
+            .unwrap();
+
+        let GotoDefinitionResponse::Scalar(location) = definition else {
+            panic!("expected a single definition location");
+        };
+        assert_eq!(location.uri, target_uri);
+        assert_eq!(location.range.start.line, 2);
+    }
+
+    #[test]
+    fn navigation_request_returns_definition_for_wiki_heading_anchor() {
+        let (_vault_dir, state, source_uri, target_uri, source_text) = heading_anchor_navigation_state();
+
+        let definition = state
+            .navigation_request(
+                source_uri,
+                position_for_substring(&source_text, "[[target-id#Linked Heading]]"),
+            )
+            .unwrap()
+            .compute_definition()
+            .unwrap()
+            .unwrap();
+
+        let GotoDefinitionResponse::Scalar(location) = definition else {
+            panic!("expected a single definition location");
+        };
+        assert_eq!(location.uri.path(), target_uri.path());
+        assert_eq!(location.uri.fragment(), Some("Linked%20Heading"));
+        assert_eq!(location.range.start.line, 7);
+        assert_eq!(location.range.start.character, 3);
+    }
+
+    #[test]
+    fn navigation_request_returns_definition_for_markdown_heading_anchor() {
+        let (_vault_dir, state, source_uri, target_uri, source_text) = heading_anchor_navigation_state();
+
+        let definition = state
+            .navigation_request(
+                source_uri,
+                position_for_substring(&source_text, "[Target Markdown](target.md#linked-heading)"),
+            )
+            .unwrap()
+            .compute_definition()
+            .unwrap()
+            .unwrap();
+
+        let GotoDefinitionResponse::Scalar(location) = definition else {
+            panic!("expected a single definition location");
+        };
+        assert_eq!(location.uri.path(), target_uri.path());
+        assert_eq!(location.uri.fragment(), Some("linked-heading"));
+        assert_eq!(location.range.start.line, 7);
+        assert_eq!(location.range.start.character, 3);
+    }
+
+    #[test]
+    fn navigation_request_returns_definition_for_nested_wiki_heading_anchor() {
+        let (_vault_dir, state, source_uri, target_uri, source_text) = nested_heading_anchor_navigation_state();
+
+        let definition = state
+            .navigation_request(
+                source_uri,
+                position_for_substring(&source_text, "[[target-id#Heading A#Subheading B]]"),
+            )
+            .unwrap()
+            .compute_definition()
+            .unwrap()
+            .unwrap();
+
+        let GotoDefinitionResponse::Scalar(location) = definition else {
+            panic!("expected a single definition location");
+        };
+        assert_eq!(location.uri.path(), target_uri.path());
+        assert_eq!(location.uri.fragment(), Some("Heading%20A#Subheading%20B"));
+        assert_eq!(location.range.start.line, 11);
+        assert_eq!(location.range.start.character, 3);
+    }
+
+    #[test]
+    fn navigation_request_returns_definition_for_nested_slug_heading_anchor() {
+        let (_vault_dir, state, source_uri, target_uri, source_text) = nested_heading_anchor_navigation_state();
+
+        let definition = state
+            .navigation_request(
+                source_uri,
+                position_for_substring(&source_text, "[[target-id#heading-a#subheading-b]]"),
+            )
+            .unwrap()
+            .compute_definition()
+            .unwrap()
+            .unwrap();
+
+        let GotoDefinitionResponse::Scalar(location) = definition else {
+            panic!("expected a single definition location");
+        };
+        assert_eq!(location.uri.path(), target_uri.path());
+        assert_eq!(location.uri.fragment(), Some("heading-a#subheading-b"));
+        assert_eq!(location.range.start.line, 11);
+        assert_eq!(location.range.start.character, 3);
+    }
+
+    #[test]
+    fn navigation_request_returns_definition_for_nested_markdown_heading_anchor() {
+        let (_vault_dir, state, source_uri, target_uri, source_text) = nested_heading_anchor_navigation_state();
+
+        let definition = state
+            .navigation_request(
+                source_uri,
+                position_for_substring(&source_text, "[Target Markdown](target.md#heading-a#subheading-b)"),
+            )
+            .unwrap()
+            .compute_definition()
+            .unwrap()
+            .unwrap();
+
+        let GotoDefinitionResponse::Scalar(location) = definition else {
+            panic!("expected a single definition location");
+        };
+        assert_eq!(location.uri.path(), target_uri.path());
+        assert_eq!(location.uri.fragment(), Some("heading-a#subheading-b"));
+        assert_eq!(location.range.start.line, 11);
+        assert_eq!(location.range.start.character, 3);
     }
 }

--- a/obsidian-lsp/src/uri.rs
+++ b/obsidian-lsp/src/uri.rs
@@ -1,0 +1,90 @@
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+use tower_lsp::lsp_types::Url;
+
+#[derive(Debug, Error)]
+pub enum UriError {
+    #[error("URI '{0}' is not a file URI")]
+    NotAFileUri(Url),
+    #[error("path '{0}' could not be converted to a file URI")]
+    InvalidPath(PathBuf),
+    #[error("path '{path}' is outside vault root '{vault_root}'")]
+    PathOutsideVault { path: PathBuf, vault_root: PathBuf },
+}
+
+pub fn uri_to_path(uri: &Url) -> Result<PathBuf, UriError> {
+    uri.to_file_path()
+        .map(normalize_path)
+        .map_err(|()| UriError::NotAFileUri(uri.clone()))
+}
+
+pub fn path_to_uri(path: &Path) -> Result<Url, UriError> {
+    let normalized = normalize_path(path);
+    Url::from_file_path(&normalized).map_err(|()| UriError::InvalidPath(normalized))
+}
+
+pub fn vault_relative_path(vault_root: &Path, path: &Path) -> Result<PathBuf, UriError> {
+    path.strip_prefix(vault_root)
+        .map(Path::to_path_buf)
+        .map_err(|_| UriError::PathOutsideVault {
+            path: path.to_path_buf(),
+            vault_root: vault_root.to_path_buf(),
+        })
+}
+
+fn normalize_path(path: impl AsRef<Path>) -> PathBuf {
+    obsidian_core::common::normalize_path(path, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn path_to_uri_round_trips_file_paths() {
+        let vault_dir = tempfile::tempdir().unwrap();
+        let note_path = vault_dir.path().join("Daily Note.md");
+        fs::write(&note_path, "body").unwrap();
+        let note_path = note_path.canonicalize().unwrap();
+
+        let uri = path_to_uri(&note_path).unwrap();
+        let round_trip = uri_to_path(&uri).unwrap();
+
+        assert_eq!(round_trip, note_path);
+    }
+
+    #[test]
+    fn uri_to_path_rejects_non_file_uris() {
+        let uri = Url::parse("untitled:Daily%20Note").unwrap();
+
+        let error = uri_to_path(&uri).unwrap_err();
+
+        assert!(matches!(error, UriError::NotAFileUri(actual) if actual == uri));
+    }
+
+    #[test]
+    fn vault_relative_path_returns_vault_relative_note_path() {
+        let vault_root = PathBuf::from("/vault");
+        let note_path = vault_root.join("notes/daily/today.md");
+
+        let relative = vault_relative_path(&vault_root, &note_path).unwrap();
+
+        assert_eq!(relative, PathBuf::from("notes/daily/today.md"));
+    }
+
+    #[test]
+    fn vault_relative_path_errors_for_paths_outside_the_vault() {
+        let vault_root = PathBuf::from("/vault");
+        let note_path = PathBuf::from("/other-vault/today.md");
+
+        let error = vault_relative_path(&vault_root, &note_path).unwrap_err();
+
+        assert!(matches!(
+            error,
+            UriError::PathOutsideVault { path, vault_root: root }
+            if path == note_path && root == Path::new("/vault")
+        ));
+    }
+}

--- a/obsidian-lsp/tests/lsp_integration.rs
+++ b/obsidian-lsp/tests/lsp_integration.rs
@@ -1,0 +1,512 @@
+use std::collections::VecDeque;
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, Stdio};
+use std::sync::{Arc, Mutex, mpsc};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::{Value, json};
+use tower_lsp::lsp_types::Url;
+
+const MESSAGE_TIMEOUT: Duration = Duration::from_secs(5);
+const EXIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct LspHarness {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    messages: mpsc::Receiver<Value>,
+    backlog: VecDeque<Value>,
+    stderr: Arc<Mutex<String>>,
+}
+
+impl LspHarness {
+    fn spawn(vault_path: &Path) -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_obsidian-lsp"))
+            .arg("--vault")
+            .arg(vault_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("should spawn obsidian-lsp");
+
+        let stdin = child.stdin.take().expect("child stdin should be piped");
+        let stdout = child.stdout.take().expect("child stdout should be piped");
+        let stderr = child.stderr.take().expect("child stderr should be piped");
+
+        let (sender, receiver) = mpsc::channel();
+        let stderr_output = Arc::new(Mutex::new(String::new()));
+
+        spawn_stdout_reader(stdout, sender);
+        spawn_stderr_reader(stderr, Arc::clone(&stderr_output));
+
+        Self {
+            child,
+            stdin: Some(stdin),
+            messages: receiver,
+            backlog: VecDeque::new(),
+            stderr: stderr_output,
+        }
+    }
+
+    fn send(&mut self, message: Value) {
+        let stdin = self.stdin.as_mut().expect("stdin should still be open");
+        let bytes = serde_json::to_vec(&message).expect("message should serialize");
+        write!(stdin, "Content-Length: {}\r\n\r\n", bytes.len()).expect("should write LSP header");
+        stdin.write_all(&bytes).expect("should write LSP body");
+        stdin.flush().expect("should flush message");
+    }
+
+    fn expect_message<F>(&mut self, description: &str, mut predicate: F) -> Value
+    where
+        F: FnMut(&Value) -> bool,
+    {
+        if let Some(index) = self.backlog.iter().position(&mut predicate) {
+            return self
+                .backlog
+                .remove(index)
+                .expect("backlog entry at reported index should exist");
+        }
+
+        let deadline = Instant::now() + MESSAGE_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let message = self.messages.recv_timeout(remaining).unwrap_or_else(|_| {
+                panic!(
+                    "timed out waiting for {description}; stderr so far:\n{}",
+                    self.stderr_snapshot()
+                )
+            });
+
+            if predicate(&message) {
+                return message;
+            }
+
+            self.backlog.push_back(message);
+        }
+    }
+
+    fn wait_for_exit(&mut self) {
+        self.stdin.take();
+        let deadline = Instant::now() + EXIT_TIMEOUT;
+        loop {
+            match self.child.try_wait().expect("should query child status") {
+                Some(status) => {
+                    assert!(
+                        status.success(),
+                        "obsidian-lsp exited unsuccessfully ({status}); stderr:\n{}",
+                        self.stderr_snapshot()
+                    );
+                    return;
+                }
+                None if Instant::now() < deadline => thread::sleep(Duration::from_millis(10)),
+                None => {
+                    let _ = self.child.kill();
+                    let _ = self.child.wait();
+                    panic!(
+                        "timed out waiting for obsidian-lsp to exit; stderr:\n{}",
+                        self.stderr_snapshot()
+                    );
+                }
+            }
+        }
+    }
+
+    fn stderr_snapshot(&self) -> String {
+        self.stderr.lock().expect("stderr lock should not be poisoned").clone()
+    }
+}
+
+impl Drop for LspHarness {
+    fn drop(&mut self) {
+        if let Ok(None) = self.child.try_wait() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+fn spawn_stdout_reader(stdout: ChildStdout, sender: mpsc::Sender<Value>) {
+    thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        while let Some(message) = read_message(&mut reader) {
+            if sender.send(message).is_err() {
+                return;
+            }
+        }
+    });
+}
+
+fn spawn_stderr_reader(stderr: ChildStderr, output: Arc<Mutex<String>>) {
+    thread::spawn(move || {
+        let mut reader = BufReader::new(stderr);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => return,
+                Ok(_) => output
+                    .lock()
+                    .expect("stderr lock should not be poisoned")
+                    .push_str(&line),
+                Err(_) => return,
+            }
+        }
+    });
+}
+
+fn read_message(reader: &mut BufReader<ChildStdout>) -> Option<Value> {
+    let mut content_length = None;
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) => return None,
+            Ok(_) => {
+                if line == "\r\n" {
+                    break;
+                }
+
+                let (name, value) = line
+                    .split_once(':')
+                    .expect("LSP headers should contain a ':' delimiter");
+                if name.eq_ignore_ascii_case("Content-Length") {
+                    content_length = Some(
+                        value
+                            .trim()
+                            .parse::<usize>()
+                            .expect("Content-Length header should contain a number"),
+                    );
+                }
+            }
+            Err(_) => return None,
+        }
+    }
+
+    let mut content = vec![0; content_length.expect("LSP messages should include Content-Length header")];
+    reader
+        .read_exact(&mut content)
+        .expect("should read the full JSON-RPC payload");
+
+    Some(serde_json::from_slice(&content).expect("payload should be valid JSON"))
+}
+
+fn request(id: i64, method: &str, params: Option<Value>) -> Value {
+    let mut message = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+    });
+
+    if let Some(params) = params {
+        message
+            .as_object_mut()
+            .expect("request message should be an object")
+            .insert("params".to_string(), params);
+    }
+
+    message
+}
+
+fn notification(method: &str, params: Option<Value>) -> Value {
+    let mut message = json!({
+        "jsonrpc": "2.0",
+        "method": method,
+    });
+
+    if let Some(params) = params {
+        message
+            .as_object_mut()
+            .expect("notification message should be an object")
+            .insert("params".to_string(), params);
+    }
+
+    message
+}
+
+fn initialize_session(harness: &mut LspHarness, vault_uri: &Url, vault_path: &Path) {
+    harness.send(request(
+        1,
+        "initialize",
+        Some(json!({
+            "processId": null,
+            "rootUri": vault_uri,
+            "capabilities": {},
+        })),
+    ));
+
+    let initialize = harness.expect_message("initialize response", |message| message["id"] == 1);
+    assert_eq!(initialize["jsonrpc"], "2.0");
+    assert_eq!(initialize["result"]["capabilities"]["textDocumentSync"], 1);
+    assert_eq!(initialize["result"]["capabilities"]["hoverProvider"], true);
+    assert_eq!(initialize["result"]["serverInfo"]["name"], "obsidian-rs-lsp");
+    assert_eq!(initialize["result"]["serverInfo"]["version"], env!("CARGO_PKG_VERSION"));
+
+    harness.send(notification("initialized", Some(json!({}))));
+
+    let log_message = harness.expect_message("window/logMessage notification", |message| {
+        message["method"] == "window/logMessage"
+    });
+    assert_eq!(log_message["params"]["type"], 3);
+    assert!(
+        log_message["params"]["message"]
+            .as_str()
+            .expect("log message should be a string")
+            .contains(vault_path.to_string_lossy().as_ref())
+    );
+}
+
+fn shutdown_session(harness: &mut LspHarness) {
+    harness.send(request(99, "shutdown", None));
+
+    let shutdown = harness.expect_message("shutdown response", |message| message["id"] == 99);
+    assert_eq!(shutdown["jsonrpc"], "2.0");
+    assert!(shutdown["result"].is_null());
+
+    harness.send(notification("exit", None));
+    harness.wait_for_exit();
+}
+
+fn expect_diagnostics(harness: &mut LspHarness, uri: &Url, version: Option<i32>) -> Value {
+    harness.expect_message("publishDiagnostics notification", |message| {
+        if message["method"] != "textDocument/publishDiagnostics" || message["params"]["uri"] != uri.as_str() {
+            return false;
+        }
+
+        match version {
+            Some(version) => message["params"]["version"] == json!(version),
+            None => message["params"]
+                .as_object()
+                .expect("diagnostics params should be an object")
+                .get("version")
+                .is_none(),
+        }
+    })
+}
+
+fn diagnostic_codes(message: &Value) -> Vec<&str> {
+    message["params"]["diagnostics"]
+        .as_array()
+        .expect("diagnostics should be an array")
+        .iter()
+        .filter_map(|diagnostic| diagnostic["code"].as_str())
+        .collect()
+}
+
+fn position_for_substring(text: &str, needle: &str) -> (u32, u32) {
+    for (line_index, line) in text.lines().enumerate() {
+        if let Some(column) = line.find(needle) {
+            return (line_index as u32, column as u32 + 2);
+        }
+    }
+
+    panic!("substring '{needle}' not found");
+}
+
+fn create_test_vault() -> (tempfile::TempDir, PathBuf, Url) {
+    let vault_dir = tempfile::tempdir().expect("should create temp dir");
+    fs::create_dir(vault_dir.path().join(".obsidian")).expect("should create .obsidian directory");
+
+    let note_path = vault_dir.path().join("notes/today.md");
+    fs::create_dir_all(note_path.parent().expect("note should have a parent")).expect("should create note directory");
+    fs::write(&note_path, "original body").expect("should write test note");
+
+    let note_path = note_path.canonicalize().expect("note path should canonicalize");
+    let note_uri = Url::from_file_path(&note_path).expect("note path should convert to file URI");
+
+    (vault_dir, note_path, note_uri)
+}
+
+fn create_feature_vault() -> (tempfile::TempDir, Url, Url, String) {
+    let vault_dir = tempfile::tempdir().expect("should create temp dir");
+    fs::create_dir(vault_dir.path().join(".obsidian")).expect("should create .obsidian directory");
+
+    let target_path = vault_dir.path().join("target.md");
+    fs::write(
+        &target_path,
+        "---\nid: target-id\ntitle: Target Note\naliases: [target-alias]\ntags: [rust]\n---\n\nBody.\n",
+    )
+    .expect("should write target note");
+
+    let duplicate_a_path = vault_dir.path().join("duplicate-a.md");
+    let duplicate_a_text =
+        "---\nid: shared-id\naliases: [shared-alias]\n---\n\nSee [[missing-note]] and [[target-id]].\n";
+    fs::write(&duplicate_a_path, duplicate_a_text).expect("should write duplicate note A");
+    let duplicate_a_uri = Url::from_file_path(
+        duplicate_a_path
+            .canonicalize()
+            .expect("duplicate note A path should canonicalize"),
+    )
+    .expect("duplicate note A path should convert to file URI");
+
+    let duplicate_b_path = vault_dir.path().join("duplicate-b.md");
+    fs::write(
+        &duplicate_b_path,
+        "---\nid: shared-id\naliases: [shared-alias]\n---\n\nBody.\n",
+    )
+    .expect("should write duplicate note B");
+    let duplicate_b_uri = Url::from_file_path(
+        duplicate_b_path
+            .canonicalize()
+            .expect("duplicate note B path should canonicalize"),
+    )
+    .expect("duplicate note B path should convert to file URI");
+
+    (
+        vault_dir,
+        duplicate_a_uri,
+        duplicate_b_uri,
+        duplicate_a_text.to_string(),
+    )
+}
+
+#[test]
+fn stdio_session_handles_initialize_and_document_lifecycle() {
+    let (vault_dir, note_path, note_uri) = create_test_vault();
+    let vault_path = vault_dir.path().canonicalize().expect("vault path should canonicalize");
+    let vault_uri = Url::from_file_path(&vault_path).expect("vault path should convert to file URI");
+
+    let mut harness = LspHarness::spawn(vault_dir.path());
+    initialize_session(&mut harness, &vault_uri, &vault_path);
+
+    harness.send(notification(
+        "textDocument/didOpen",
+        Some(json!({
+            "textDocument": {
+                "uri": note_uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": "opened body",
+            }
+        })),
+    ));
+
+    let open_diagnostics = harness.expect_message("didOpen diagnostics", |message| {
+        message["method"] == "textDocument/publishDiagnostics"
+            && message["params"]["uri"] == note_uri.as_str()
+            && message["params"]["version"] == 1
+    });
+    assert_eq!(open_diagnostics["params"]["diagnostics"], json!([]));
+
+    harness.send(notification(
+        "textDocument/didChange",
+        Some(json!({
+            "textDocument": {
+                "uri": note_uri,
+                "version": 2,
+            },
+            "contentChanges": [
+                {
+                    "text": "changed body",
+                }
+            ],
+        })),
+    ));
+
+    let change_diagnostics = harness.expect_message("didChange diagnostics", |message| {
+        message["method"] == "textDocument/publishDiagnostics"
+            && message["params"]["uri"] == note_uri.as_str()
+            && message["params"]["version"] == 2
+    });
+    assert_eq!(change_diagnostics["params"]["diagnostics"], json!([]));
+
+    harness.send(notification(
+        "textDocument/didClose",
+        Some(json!({
+            "textDocument": {
+                "uri": note_uri,
+            }
+        })),
+    ));
+
+    let close_diagnostics = harness.expect_message("didClose diagnostics", |message| {
+        message["method"] == "textDocument/publishDiagnostics" && message["params"]["uri"] == note_uri.as_str()
+    });
+    assert_eq!(close_diagnostics["params"]["diagnostics"], json!([]));
+    assert!(
+        close_diagnostics["params"]
+            .as_object()
+            .expect("diagnostics params should be an object")
+            .get("version")
+            .is_none()
+    );
+
+    shutdown_session(&mut harness);
+
+    let final_body = fs::read_to_string(note_path).expect("should be able to read note after LSP session");
+    assert_eq!(final_body, "original body");
+}
+
+#[test]
+fn stdio_session_reports_health_diagnostics_and_hover_metadata() {
+    let (vault_dir, duplicate_a_uri, duplicate_b_uri, duplicate_a_text) = create_feature_vault();
+    let vault_path = vault_dir.path().canonicalize().expect("vault path should canonicalize");
+    let vault_uri = Url::from_file_path(&vault_path).expect("vault path should convert to file URI");
+    let (hover_line, hover_character) = position_for_substring(&duplicate_a_text, "[[target-id]]");
+
+    let mut harness = LspHarness::spawn(vault_dir.path());
+    initialize_session(&mut harness, &vault_uri, &vault_path);
+
+    harness.send(notification(
+        "textDocument/didOpen",
+        Some(json!({
+            "textDocument": {
+                "uri": duplicate_a_uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": duplicate_a_text,
+            }
+        })),
+    ));
+
+    let duplicate_a_diagnostics = expect_diagnostics(&mut harness, &duplicate_a_uri, Some(1));
+    assert_eq!(
+        diagnostic_codes(&duplicate_a_diagnostics),
+        vec!["duplicate-id", "duplicate-alias", "broken-link"]
+    );
+    assert!(
+        duplicate_a_diagnostics["params"]["diagnostics"]
+            .as_array()
+            .expect("diagnostics should be an array")
+            .iter()
+            .any(|diagnostic| diagnostic["message"]
+                .as_str()
+                .unwrap()
+                .contains("Broken link [[missing-note]]"))
+    );
+
+    let duplicate_b_diagnostics = expect_diagnostics(&mut harness, &duplicate_b_uri, None);
+    assert_eq!(
+        diagnostic_codes(&duplicate_b_diagnostics),
+        vec!["duplicate-id", "duplicate-alias"]
+    );
+
+    harness.send(request(
+        2,
+        "textDocument/hover",
+        Some(json!({
+            "textDocument": {
+                "uri": duplicate_a_uri,
+            },
+            "position": {
+                "line": hover_line,
+                "character": hover_character,
+            }
+        })),
+    ));
+
+    let hover = harness.expect_message("hover response", |message| message["id"] == 2);
+    let hover_text = hover["result"]["contents"]["value"]
+        .as_str()
+        .expect("hover response should contain markdown text");
+    assert!(hover_text.contains("Target Note"));
+    assert!(hover_text.contains("target-id"));
+    assert!(hover_text.contains("target-alias"));
+    assert!(hover_text.contains("rust"));
+    assert!(hover_text.contains("target.md"));
+
+    shutdown_session(&mut harness);
+}

--- a/obsidian-lsp/tests/lsp_integration.rs
+++ b/obsidian-lsp/tests/lsp_integration.rs
@@ -242,6 +242,12 @@ fn initialize_session(harness: &mut LspHarness, vault_uri: &Url, vault_path: &Pa
     assert_eq!(initialize["jsonrpc"], "2.0");
     assert_eq!(initialize["result"]["capabilities"]["textDocumentSync"], 1);
     assert_eq!(initialize["result"]["capabilities"]["hoverProvider"], true);
+    assert_eq!(initialize["result"]["capabilities"]["referencesProvider"], true);
+    assert_eq!(initialize["result"]["capabilities"]["definitionProvider"], true);
+    assert_eq!(
+        initialize["result"]["capabilities"]["documentLinkProvider"]["resolveProvider"],
+        true
+    );
     assert_eq!(initialize["result"]["serverInfo"]["name"], "obsidian-rs-lsp");
     assert_eq!(initialize["result"]["serverInfo"]["version"], env!("CARGO_PKG_VERSION"));
 
@@ -296,6 +302,12 @@ fn diagnostic_codes(message: &Value) -> Vec<&str> {
         .collect()
 }
 
+fn raw_link(document_link: &Value) -> &str {
+    document_link["data"]["rawLink"]
+        .as_str()
+        .expect("document link should include rawLink data")
+}
+
 fn position_for_substring(text: &str, needle: &str) -> (u32, u32) {
     for (line_index, line) in text.lines().enumerate() {
         if let Some(column) = line.find(needle) {
@@ -320,7 +332,7 @@ fn create_test_vault() -> (tempfile::TempDir, PathBuf, Url) {
     (vault_dir, note_path, note_uri)
 }
 
-fn create_feature_vault() -> (tempfile::TempDir, Url, Url, String) {
+fn create_feature_vault() -> (tempfile::TempDir, Url, Url, Url, Url, String) {
     let vault_dir = tempfile::tempdir().expect("should create temp dir");
     fs::create_dir(vault_dir.path().join(".obsidian")).expect("should create .obsidian directory");
 
@@ -330,10 +342,11 @@ fn create_feature_vault() -> (tempfile::TempDir, Url, Url, String) {
         "---\nid: target-id\ntitle: Target Note\naliases: [target-alias]\ntags: [rust]\n---\n\nBody.\n",
     )
     .expect("should write target note");
+    let target_uri = Url::from_file_path(target_path.canonicalize().expect("target path should canonicalize"))
+        .expect("target path should convert to file URI");
 
     let duplicate_a_path = vault_dir.path().join("duplicate-a.md");
-    let duplicate_a_text =
-        "---\nid: shared-id\naliases: [shared-alias]\n---\n\nSee [[missing-note]] and [[target-id]].\n";
+    let duplicate_a_text = "---\nid: shared-id\naliases: [shared-alias]\n---\n\nSee [[missing-note]], [[target-id]], and [Target Markdown](target.md).\n";
     fs::write(&duplicate_a_path, duplicate_a_text).expect("should write duplicate note A");
     let duplicate_a_uri = Url::from_file_path(
         duplicate_a_path
@@ -355,12 +368,85 @@ fn create_feature_vault() -> (tempfile::TempDir, Url, Url, String) {
     )
     .expect("duplicate note B path should convert to file URI");
 
+    let backlink_path = vault_dir.path().join("backlink.md");
+    fs::write(&backlink_path, "Another reference to [[target-id]].\n").expect("should write backlink note");
+    let backlink_uri = Url::from_file_path(
+        backlink_path
+            .canonicalize()
+            .expect("backlink note path should canonicalize"),
+    )
+    .expect("backlink note path should convert to file URI");
+
     (
         vault_dir,
         duplicate_a_uri,
         duplicate_b_uri,
+        target_uri,
+        backlink_uri,
         duplicate_a_text.to_string(),
     )
+}
+
+fn create_heading_anchor_vault() -> (tempfile::TempDir, Url, Url, String) {
+    let vault_dir = tempfile::tempdir().expect("should create temp dir");
+    fs::create_dir(vault_dir.path().join(".obsidian")).expect("should create .obsidian directory");
+
+    let target_path = vault_dir.path().join("target.md");
+    fs::write(
+        &target_path,
+        "---\nid: target-id\ntitle: Target Note\n---\n\n# Overview\n\n## Linked Heading\nBody.\n",
+    )
+    .expect("should write target note");
+    let target_uri = Url::from_file_path(target_path.canonicalize().expect("target path should canonicalize"))
+        .expect("target path should convert to file URI");
+
+    let source_path = vault_dir.path().join("source.md");
+    let source_text = "See [[target-id#Linked Heading]] and [Target Markdown](target.md#linked-heading).\n";
+    fs::write(&source_path, source_text).expect("should write source note");
+    let source_uri = Url::from_file_path(source_path.canonicalize().expect("source path should canonicalize"))
+        .expect("source path should convert to file URI");
+
+    (vault_dir, source_uri, target_uri, source_text.to_string())
+}
+
+fn create_nested_heading_anchor_vault() -> (tempfile::TempDir, Url, Url, String) {
+    let vault_dir = tempfile::tempdir().expect("should create temp dir");
+    fs::create_dir(vault_dir.path().join(".obsidian")).expect("should create .obsidian directory");
+
+    let target_path = vault_dir.path().join("target.md");
+    fs::write(
+        &target_path,
+        concat!(
+            "---\n",
+            "id: target-id\n",
+            "title: Target Note\n",
+            "---\n",
+            "\n",
+            "# Other Heading\n",
+            "\n",
+            "## Subheading B\n",
+            "\n",
+            "# Heading A\n",
+            "\n",
+            "## Subheading B\n",
+            "Body.\n",
+        ),
+    )
+    .expect("should write target note");
+    let target_uri = Url::from_file_path(target_path.canonicalize().expect("target path should canonicalize"))
+        .expect("target path should convert to file URI");
+
+    let source_path = vault_dir.path().join("source.md");
+    let source_text = concat!(
+        "See [[target-id#Heading A#Subheading B]], ",
+        "[[target-id#heading-a#subheading-b]], ",
+        "and [Target Markdown](target.md#heading-a#subheading-b).\n"
+    );
+    fs::write(&source_path, source_text).expect("should write source note");
+    let source_uri = Url::from_file_path(source_path.canonicalize().expect("source path should canonicalize"))
+        .expect("source path should convert to file URI");
+
+    (vault_dir, source_uri, target_uri, source_text.to_string())
 }
 
 #[test]
@@ -442,7 +528,8 @@ fn stdio_session_handles_initialize_and_document_lifecycle() {
 
 #[test]
 fn stdio_session_reports_health_diagnostics_and_hover_metadata() {
-    let (vault_dir, duplicate_a_uri, duplicate_b_uri, duplicate_a_text) = create_feature_vault();
+    let (vault_dir, duplicate_a_uri, duplicate_b_uri, target_uri, backlink_uri, duplicate_a_text) =
+        create_feature_vault();
     let vault_path = vault_dir.path().canonicalize().expect("vault path should canonicalize");
     let vault_uri = Url::from_file_path(&vault_path).expect("vault path should convert to file URI");
     let (hover_line, hover_character) = position_for_substring(&duplicate_a_text, "[[target-id]]");
@@ -507,6 +594,317 @@ fn stdio_session_reports_health_diagnostics_and_hover_metadata() {
     assert!(hover_text.contains("target-alias"));
     assert!(hover_text.contains("rust"));
     assert!(hover_text.contains("target.md"));
+
+    harness.send(request(
+        3,
+        "textDocument/documentLink",
+        Some(json!({
+            "textDocument": {
+                "uri": duplicate_a_uri,
+            }
+        })),
+    ));
+
+    let document_links = harness.expect_message("documentLink response", |message| message["id"] == 3);
+    let document_links = document_links["result"]
+        .as_array()
+        .expect("documentLink response should be an array");
+    assert_eq!(document_links.len(), 3);
+    assert!(
+        document_links
+            .iter()
+            .all(|document_link| { document_link.get("target").is_none_or(|target| target.is_null()) })
+    );
+
+    let wiki_link = document_links
+        .iter()
+        .find(|document_link| raw_link(document_link) == "[[target-id]]")
+        .cloned()
+        .expect("documentLink response should include the wiki note link");
+    let markdown_link = document_links
+        .iter()
+        .find(|document_link| raw_link(document_link) == "[Target Markdown](target.md)")
+        .cloned()
+        .expect("documentLink response should include the markdown note link");
+
+    harness.send(request(4, "documentLink/resolve", Some(wiki_link)));
+    let resolved_wiki_link = harness.expect_message("documentLink/resolve wiki response", |message| message["id"] == 4);
+    assert_eq!(resolved_wiki_link["result"]["target"], target_uri.as_str());
+    assert!(
+        resolved_wiki_link["result"]["tooltip"]
+            .as_str()
+            .expect("resolved document link should include a tooltip")
+            .contains("Target Note")
+    );
+
+    harness.send(request(5, "documentLink/resolve", Some(markdown_link)));
+    let resolved_markdown_link =
+        harness.expect_message("documentLink/resolve markdown response", |message| message["id"] == 5);
+    assert_eq!(resolved_markdown_link["result"]["target"], target_uri.as_str());
+
+    harness.send(request(
+        6,
+        "textDocument/references",
+        Some(json!({
+            "textDocument": {
+                "uri": duplicate_a_uri,
+            },
+            "position": {
+                "line": hover_line,
+                "character": hover_character,
+            },
+            "context": {
+                "includeDeclaration": true,
+            }
+        })),
+    ));
+
+    let link_references = harness.expect_message("references response", |message| message["id"] == 6);
+    let link_references = link_references["result"]
+        .as_array()
+        .expect("references response should be an array");
+    assert_eq!(link_references.len(), 3);
+    assert_eq!(
+        link_references
+            .iter()
+            .filter(|location| location["uri"] == duplicate_a_uri.as_str())
+            .count(),
+        2
+    );
+    assert!(
+        link_references
+            .iter()
+            .any(|location| location["uri"] == backlink_uri.as_str())
+    );
+
+    harness.send(request(
+        7,
+        "textDocument/references",
+        Some(json!({
+            "textDocument": {
+                "uri": target_uri,
+            },
+            "position": {
+                "line": 0,
+                "character": 0,
+            },
+            "context": {
+                "includeDeclaration": true,
+            }
+        })),
+    ));
+
+    let note_references = harness.expect_message("off-link references response", |message| message["id"] == 7);
+    let note_references = note_references["result"]
+        .as_array()
+        .expect("off-link references response should be an array");
+    assert_eq!(note_references.len(), 3);
+
+    harness.send(request(
+        8,
+        "textDocument/definition",
+        Some(json!({
+            "textDocument": {
+                "uri": duplicate_a_uri,
+            },
+            "position": {
+                "line": hover_line,
+                "character": hover_character,
+            }
+        })),
+    ));
+
+    let definition = harness.expect_message("definition response", |message| message["id"] == 8);
+    assert_eq!(definition["result"]["uri"], target_uri.as_str());
+    assert_eq!(definition["result"]["range"]["start"]["line"], 2);
+
+    shutdown_session(&mut harness);
+}
+
+#[test]
+fn stdio_session_definition_jumps_to_heading_anchor() {
+    let (vault_dir, source_uri, target_uri, source_text) = create_heading_anchor_vault();
+    let vault_uri = Url::from_directory_path(vault_dir.path()).expect("vault path should convert to file URI");
+    let mut harness = LspHarness::spawn(vault_dir.path());
+
+    initialize_session(&mut harness, &vault_uri, vault_dir.path());
+
+    harness.send(notification(
+        "textDocument/didOpen",
+        Some(json!({
+            "textDocument": {
+                "uri": source_uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": source_text,
+            }
+        })),
+    ));
+
+    harness.send(request(
+        2,
+        "textDocument/definition",
+        Some(json!({
+            "textDocument": {
+                "uri": source_uri,
+            },
+            "position": {
+                "line": position_for_substring(&source_text, "[[target-id#Linked Heading]]").0,
+                "character": position_for_substring(&source_text, "[[target-id#Linked Heading]]").1,
+            }
+        })),
+    ));
+
+    let wiki_definition = harness.expect_message("wiki heading definition response", |message| message["id"] == 2);
+    let wiki_definition_uri = Url::parse(
+        wiki_definition["result"]["uri"]
+            .as_str()
+            .expect("definition response should include a target URI"),
+    )
+    .expect("definition target should be a valid URI");
+    assert_eq!(wiki_definition_uri.path(), target_uri.path());
+    assert_eq!(wiki_definition_uri.fragment(), Some("Linked%20Heading"));
+    assert_eq!(wiki_definition["result"]["range"]["start"]["line"], 7);
+    assert_eq!(wiki_definition["result"]["range"]["start"]["character"], 3);
+
+    harness.send(request(
+        3,
+        "textDocument/definition",
+        Some(json!({
+            "textDocument": {
+                "uri": source_uri,
+            },
+            "position": {
+                "line": position_for_substring(&source_text, "[Target Markdown](target.md#linked-heading)").0,
+                "character": position_for_substring(&source_text, "[Target Markdown](target.md#linked-heading)").1,
+            }
+        })),
+    ));
+
+    let markdown_definition =
+        harness.expect_message("markdown heading definition response", |message| message["id"] == 3);
+    let markdown_definition_uri = Url::parse(
+        markdown_definition["result"]["uri"]
+            .as_str()
+            .expect("definition response should include a target URI"),
+    )
+    .expect("definition target should be a valid URI");
+    assert_eq!(markdown_definition_uri.path(), target_uri.path());
+    assert_eq!(markdown_definition_uri.fragment(), Some("linked-heading"));
+    assert_eq!(markdown_definition["result"]["range"]["start"]["line"], 7);
+    assert_eq!(markdown_definition["result"]["range"]["start"]["character"], 3);
+
+    shutdown_session(&mut harness);
+}
+
+#[test]
+fn stdio_session_definition_jumps_to_nested_heading_anchor() {
+    let (vault_dir, source_uri, target_uri, source_text) = create_nested_heading_anchor_vault();
+    let vault_uri = Url::from_directory_path(vault_dir.path()).expect("vault path should convert to file URI");
+    let mut harness = LspHarness::spawn(vault_dir.path());
+
+    initialize_session(&mut harness, &vault_uri, vault_dir.path());
+
+    harness.send(notification(
+        "textDocument/didOpen",
+        Some(json!({
+            "textDocument": {
+                "uri": source_uri,
+                "languageId": "markdown",
+                "version": 1,
+                "text": source_text,
+            }
+        })),
+    ));
+
+    let (raw_wiki_line, raw_wiki_character) =
+        position_for_substring(&source_text, "[[target-id#Heading A#Subheading B]]");
+    harness.send(request(
+        2,
+        "textDocument/definition",
+        Some(json!({
+            "textDocument": {
+                "uri": source_uri,
+            },
+            "position": {
+                "line": raw_wiki_line,
+                "character": raw_wiki_character,
+            }
+        })),
+    ));
+
+    let raw_wiki_definition =
+        harness.expect_message("nested wiki heading definition response", |message| message["id"] == 2);
+    let raw_wiki_definition_uri = Url::parse(
+        raw_wiki_definition["result"]["uri"]
+            .as_str()
+            .expect("definition response should include a target URI"),
+    )
+    .expect("definition target should be a valid URI");
+    assert_eq!(raw_wiki_definition_uri.path(), target_uri.path());
+    assert_eq!(raw_wiki_definition_uri.fragment(), Some("Heading%20A#Subheading%20B"));
+    assert_eq!(raw_wiki_definition["result"]["range"]["start"]["line"], 11);
+    assert_eq!(raw_wiki_definition["result"]["range"]["start"]["character"], 3);
+
+    let (slug_wiki_line, slug_wiki_character) =
+        position_for_substring(&source_text, "[[target-id#heading-a#subheading-b]]");
+    harness.send(request(
+        3,
+        "textDocument/definition",
+        Some(json!({
+            "textDocument": {
+                "uri": source_uri,
+            },
+            "position": {
+                "line": slug_wiki_line,
+                "character": slug_wiki_character,
+            }
+        })),
+    ));
+
+    let slug_wiki_definition = harness.expect_message("nested slug wiki heading definition response", |message| {
+        message["id"] == 3
+    });
+    let slug_wiki_definition_uri = Url::parse(
+        slug_wiki_definition["result"]["uri"]
+            .as_str()
+            .expect("definition response should include a target URI"),
+    )
+    .expect("definition target should be a valid URI");
+    assert_eq!(slug_wiki_definition_uri.path(), target_uri.path());
+    assert_eq!(slug_wiki_definition_uri.fragment(), Some("heading-a#subheading-b"));
+    assert_eq!(slug_wiki_definition["result"]["range"]["start"]["line"], 11);
+    assert_eq!(slug_wiki_definition["result"]["range"]["start"]["character"], 3);
+
+    let (markdown_line, markdown_character) =
+        position_for_substring(&source_text, "[Target Markdown](target.md#heading-a#subheading-b)");
+    harness.send(request(
+        4,
+        "textDocument/definition",
+        Some(json!({
+            "textDocument": {
+                "uri": source_uri,
+            },
+            "position": {
+                "line": markdown_line,
+                "character": markdown_character,
+            }
+        })),
+    ));
+
+    let markdown_definition = harness.expect_message("nested markdown heading definition response", |message| {
+        message["id"] == 4
+    });
+    let markdown_definition_uri = Url::parse(
+        markdown_definition["result"]["uri"]
+            .as_str()
+            .expect("definition response should include a target URI"),
+    )
+    .expect("definition target should be a valid URI");
+    assert_eq!(markdown_definition_uri.path(), target_uri.path());
+    assert_eq!(markdown_definition_uri.fragment(), Some("heading-a#subheading-b"));
+    assert_eq!(markdown_definition["result"]["range"]["start"]["line"], 11);
+    assert_eq!(markdown_definition["result"]["range"]["start"]["character"], 3);
 
     shutdown_session(&mut harness);
 }


### PR DESCRIPTION
- clean LSP initialization and shutdown
- full-document text sync for open buffers
- in-memory buffer shadowing through `obsidian_core::Vault::load_note()` / `unload_note()`
- diagnostics for broken links, duplicate IDs, and duplicate aliases across the vault
- hover on note links with basic target-note metadata
- document links for wiki and markdown note links, with resolve support
- references/backlinks for linked notes, or for the current note when the cursor is not on a link
- go-to definition for linked notes, including heading anchors and nested sub-anchors
- diagnostics clearing and refresh on open/change/close events