### PR TITLE
Fix frontmatter json example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ obsidian search --content-matches 'TODO:.*urgent'
 obsidian note list --sort modified-desc
 
 # Read a note's frontmatter as JSON
-obsidian note read "My Note" --format json
+obsidian note read "My Note" --frontmatter --format json
 
 # Rename a note and automatically update every backlink
 obsidian note rename "Old Title" "New Title"


### PR DESCRIPTION
Tiny fix for the frontmatter example, it seems that `--frontmatter` is missing, without it only the note's content is dumped in a `content` key. Thanks!


<img src="https://brainmade.org/white-logo.png" width="100em">